### PR TITLE
Adds access / requestor workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ tests/
 
 ```
 
-$ pytest
+$ pytest --cov=gen3_util
 
 collected 26 items
 
@@ -210,6 +210,10 @@ tests/unit/test_config.py ..                                                    
 tests/unit/test_files.py ...                                                                                                                                                  [ 80%]
 tests/unit/test_meta.py .                                                                                                                                                     [ 84%]
 tests/unit/test_validate_directory.py ....                                                                                                                                    [100%]
+...
+----------------------------------------------------
+TOTAL                              944    114    88%
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ $python3 -m venv venv ; source venv/bin/activate
 
 pip install gen3_util
 
-gen3_util
->>> {'msg': 'Version 0.0.1'}
+$ gen3_util
+msg: Version 0.0.1
+
 
 ```
 
@@ -22,21 +23,28 @@ gen3_util
 
 ```
 $gen3_util --help
-
 Usage: gen3_util [OPTIONS] COMMAND [ARGS]...
 
   Gen3 Management Utilities
 
 Options:
   --config TEXT              Path to config file. GEN3_UTIL_CONFIG
-  --format [yaml|json|text]  Result format. GEN3_UTIL_FORMAT
+  --format [yaml|json|text]  Result format. GEN3_UTIL_FORMAT  [default: yaml]
+  --cred TEXT                See https://uc-cdis.github.io/gen3-user-
+                             doc/appendices/api-gen3/#credentials-to-query-
+                             the-api. GEN3_API_KEY
+  --state_dir TEXT           Directory for file transfer state
+                             GEN3_UTIL_STATE_DIR  [default: ~/.gen3/gen3_util]
   --help                     Show this message and exit.
 
 Commands:
   projects  Manage Gen3 projects.
+  buckets   Manage Gen3 buckets.
   meta      Manage meta data.
   files     Manage file buckets.
+  access    Manage access requests.
   config    Configure this utility.
+
 
 ```
 
@@ -45,21 +53,45 @@ Commands:
 * Leverages Gen3Auth  [See](https://uc-cdis.github.io/gen3-user-doc/appendices/api-gen3/#credentials-to-query-the-api.)
 * Store the `credentials.json` file in ~/.gen3/credentials.json or specify location with either env[GEN3_API_KEY], or `--cred` parameter
 
+## Use cases
+
+> I need to verify connectivity.
 
 ```
 $ gen3_util projects ping
 msg: OK connected to endpoint https://aced-training.compbio.ohsu.edu
+```
 
+> I need to see what projects exist
+
+```
 $ gen3_util projects ls
+
 endpoint: https://aced-training.compbio.ohsu.edu
+msg: OK
 projects:
+- /programs
+- /programs/aced
+- /programs/aced/project
+- /programs/aced/project/MCF10A
+- /programs/aced/projects
 - /programs/aced/projects/Alcoholism
 - /programs/aced/projects/Alzheimers
 - /programs/aced/projects/Breast_Cancer
 - /programs/aced/projects/Colon_Cancer
 - /programs/aced/projects/Diabetes
+- /programs/aced/projects/HOP
 - /programs/aced/projects/Lung_Cancer
+- /programs/aced/projects/MCF10A
+- /programs/aced/projects/NVIDIA
 - /programs/aced/projects/Prostate_Cancer
+- /programs/aced/projects/ohsu_download_testing
+```
+
+> I need to see what buckets are associated with the commons
+
+```
+$ gen3_util buckets ls
 buckets:
   GS_BUCKETS: {}
   S3_BUCKETS:
@@ -78,8 +110,16 @@ buckets:
     aced-ucl:
       endpoint_url: https://minio-ucl.compbio.ohsu.edu
       region: us-east-1
+endpoint: https://aced-training.compbio.ohsu.edu
+msg: OK
 
 
+```
+
+
+> I want to create a simple project with a set of files
+
+```
 $ gen3_util meta  import dir tests/fixtures/dir_to_study/ tmp/foo --project_id aced-Alcoholism
 msg: OK
 summary:
@@ -88,7 +128,11 @@ summary:
     size: 6013814
   ResearchStudy:
     count: 1
+```
 
+> I need to upload those files to the instance
+
+```
 $ gen3_util files cp --ignore_state --project_id aced-Alcoholism tmp/foo/DocumentReference.ndjson  bucket://aced-ohsu
 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 5.74M/5.74M [00:03<00:00, 1.71MB/s, elapsed=0:00:02.056022, file=6f8101]
 errors: []
@@ -96,8 +140,11 @@ incomplete: []
 info:
 - Wrote state to ~/.gen3/gen3-util-state/state.ndjson
 msg: OK
+```
 
+> I need to request or manage access to a project
 
+```
 $ gen3_util access
 Usage: gen3_util access [OPTIONS] COMMAND [ARGS]...
 
@@ -111,8 +158,6 @@ Commands:
   update  Update the request's approval workflow.
   ls      List current user's requests.
   cat     Show details of a specific request.
-
-
 
 ```
 
@@ -153,10 +198,20 @@ tests/
 
 $ pytest
 
-tests/integration/test_project.py ...
-tests/unit/test_cli.py ......                                                                                                                                                                   [ 66%]
-tests/unit/test_coding_conventions.py .                                                                                                                                                         [ 77%]
-tests/unit/test_config.py ..
+collected 26 items
+
+tests/integration/test_access.py ..                                                                                                                                           [  7%]
+tests/integration/test_buckets.py .                                                                                                                                           [ 11%]
+tests/integration/test_files.py ..                                                                                                                                            [ 19%]
+tests/integration/test_project.py ...                                                                                                                                         [ 30%]
+tests/unit/test_cli.py .......                                                                                                                                                [ 57%]
+tests/unit/test_coding_conventions.py .                                                                                                                                       [ 61%]
+tests/unit/test_config.py ..                                                                                                                                                  [ 69%]
+tests/unit/test_files.py ...                                                                                                                                                  [ 80%]
+tests/unit/test_meta.py .                                                                                                                                                     [ 84%]
+tests/unit/test_validate_directory.py ....                                                                                                                                    [100%]
+
+
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ info:
 msg: OK
 
 
+$ gen3_util access
+Usage: gen3_util access [OPTIONS] COMMAND [ARGS]...
+
+  Manage access requests.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  touch   Create a request for read access.
+  update  Update the request's approval workflow.
+  ls      List current user's requests.
+  cat     Show details of a specific request.
+
+
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ run our unit tests.......................................................Passed
 export TWINE_USERNAME=  #  the username to use for authentication to the repository.
 export TWINE_PASSWORD=  # the password to use for authentication to the repository.
 
+# this could be maintained as so: export $(cat .env | xargs)
+
 rm -r dist/
 python3  setup.py sdist bdist_wheel
 twine upload dist/*

--- a/docs/access-workflow.md
+++ b/docs/access-workflow.md
@@ -1,0 +1,38 @@
+
+### `access` module that interfaces w/ Gen3's [requestor](https://github.com/uc-cdis/requestor)
+
+
+#### Enables `User` and `Someone who makes access decisions`
+
+> From Requestor's documentation
+
+![image](https://github.com/uc-cdis/requestor/raw/master/docs/img/requestor_example_flow.png)
+
+
+specifically:
+
+* gen3_util access `touch` USER_NAME RESOURCE_PATH implements `Fill out access request form`
+*  gen3_util access `update` REQUEST_ID STATUS implements `update access request status`
+*  gen3_util access `ls` implements `send form data`
+
+
+
+see https://github.com/uc-cdis/requestor/blob/master/docs/functionality_and_flow.md
+
+---/---
+
+
+```$ gen3_util access
+Usage: gen3_util access [OPTIONS] COMMAND [ARGS]...
+
+  Manage access requests.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  touch   Create a request for read access.
+  update  Update the request's approval workflow.
+  ls      List current user's requests.
+  cat     Show details of a specific request.
+```

--- a/docs/docker-compose-notes.md
+++ b/docs/docker-compose-notes.md
@@ -1,0 +1,76 @@
+#### Notes:
+
+
+Arborist has a usr table, full of users synced from user.yaml.  It also has tables usr_grp, grp and grp_policy all populated from the user.yaml sync.    Arborist also has apis to add users, groups etc.   They are not exposed outside of the cluster.  This is probably a good idea.  Appropriately, it is up to something within the cluster to access those APIs, in this case Requestor.
+
+Requestor will read policies and permissions from arborist regarding a users ability to request and grant access by user. e.g: [user.yaml](https://ohsuitg-my.sharepoint.com/:u:/r/personal/walsbr_ohsu_edu/Documents/[aced-staging-requestor-05-11-2023.yaml](https://ohsuitg-my.sharepoint.com/:u:/r/personal/walsbr_ohsu_edu/Documents/aced-staging-requestor-05-11-2023.yaml?csf=1&web=1&e=LhW55g)?csf=1&web=1&e=LhW55g)
+
+docker-compose snippets:
+
+```
+  requestor-service:
+    build: requestor
+    # image: "quay.io/cdis/requestor"
+    container_name: requestor-service
+    networks:
+      - devnet
+    volumes:
+      - ./Secrets/requestor-config.yaml:/src/requestor-config.yaml
+    environment:
+      - DB_DATABASE=requestor_db
+      - DB_USER=XXXXX
+      - DB_PASSWORD=XXXXX
+      - DB_HOST=postgres
+      - DB_PORT=5432
+      - PGSSLMODE=disable
+      - GEN3_ARBORIST_ENDPOINT=http://arborist-service
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost/health"]
+      interval: 60s
+      timeout: 5s
+      retries: 10
+
+    # note: requestor's auth client get's the "iss" claim of the JWT token and will connect and validate against that url.
+    # therefore, if that endpoint is not a public DNS entry, the requestor's container needs to resolve that host
+    # eg.
+    extra_hosts:
+     - "aced-training.compbio.ohsu.edu:THE-IP-ADDRESS-OF-THE-HOST-OS"
+
+```
+
+revproxy-service nginx snippet:
+```
+      location /requestor/ {
+          rewrite ^/requestor/(.*) /$1 break;
+          auth_request_set $saved_set_cookie $upstream_http_set_cookie;
+          proxy_pass http://requestor-service/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $http_connection;
+            proxy_set_header Authorization "$access_token";
+            client_max_body_size 0;
+      }
+```
+
+
+postgres setup:
+
+In `scripts/postgres_init.sql`
+
+```
+CREATE DATABASE arborist_db;
+CREATE USER requestor_user;
+ALTER USER requestor_user WITH PASSWORD 'XXXXX';
+ALTER USER requestor_user WITH SUPERUSER;
+```
+
+> helm
+The [helm chart](https://github.com/uc-cdis/gen3-helm/tree/master/helm/requestor) seems complete.  We have yet to test.
+
+
+See more:
+
+https://github.com/uc-cdis/requestor/blob/master/docs/authorization.md

--- a/gen3_util/access/__init__.py
+++ b/gen3_util/access/__init__.py
@@ -51,30 +51,3 @@ def update_request(config: Config = None, auth: Gen3Auth = None, request_id: str
     )
     response.raise_for_status()
     return response.json()
-
-
-def user_ls(config: Config = None, auth: Gen3Auth = None, user_name: str = None):
-    """List accesses for user"""
-    assert user_name, "required"
-    auth = _ensure_auth(auth, config)
-    response = requests.get(
-        auth.endpoint + "/" + f'arborist/user/{user_name}', auth=auth
-    )
-    response.raise_for_status()
-    return response.json()
-
-
-def user_touch(config: Config = None, auth: Gen3Auth = None, user_name: str = None):
-    """List accesses for user"""
-    assert user_name, "required"
-    auth = _ensure_auth(auth, config)
-    data = {
-        "name": user_name,
-        "email": user_name,
-    }
-    url = auth.endpoint + "/" + 'arborist/user'
-    response = requests.post(
-        url, auth=auth, json=data
-    )
-    response.raise_for_status()
-    return response.json()

--- a/gen3_util/access/__init__.py
+++ b/gen3_util/access/__init__.py
@@ -1,0 +1,80 @@
+import requests
+from gen3.auth import Gen3Auth
+
+from gen3_util.config import ensure_auth, Config
+
+
+def _ensure_auth(auth, config):
+    """Create auth from config, if we don't have one already."""
+    if not auth:
+        assert config
+        auth = ensure_auth(config.gen3.refresh_file)
+    return auth
+
+
+def get_requests(config: Config = None, auth: Gen3Auth = None, mine: bool = False) -> dict:
+    """Fetch information about the user."""
+    auth = _ensure_auth(auth, config)
+    if mine:
+        return auth.curl('/requestor/request/user').json()
+    else:
+        return auth.curl('/requestor/request').json()
+
+
+def get_request(config: Config = None, auth: Gen3Auth = None, request_id: str = None):
+    """Get a specific request"""
+    assert request_id, "required"
+    auth = _ensure_auth(auth, config)
+    return auth.curl(f'/requestor/request/{request_id}').json()
+
+
+def create_request(config: Config = None, auth: Gen3Auth = None, resource_path: str = None):
+    """Get a specific request"""
+    assert resource_path, "required"
+    auth = _ensure_auth(auth, config)
+    request = {'resource_path': resource_path, "username": "foo@bar.com"}  # , 'policy_id': 'aced_reader'
+    response = requests.post(
+        auth.endpoint + "/" + 'requestor/request', json=request, auth=auth
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def update_request(config: Config = None, auth: Gen3Auth = None, request_id: str = None, status: str = None):
+    """Update a specific request"""
+    assert request_id, "required"
+    assert status, "required"
+    auth = _ensure_auth(auth, config)
+    request = {'status': status}
+    response = requests.put(
+        auth.endpoint + "/" + f'requestor/request/{request_id}', json=request, auth=auth
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def user_ls(config: Config = None, auth: Gen3Auth = None, user_name: str = None):
+    """List accesses for user"""
+    assert user_name, "required"
+    auth = _ensure_auth(auth, config)
+    response = requests.get(
+        auth.endpoint + "/" + f'arborist/user/{user_name}', auth=auth
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def user_touch(config: Config = None, auth: Gen3Auth = None, user_name: str = None):
+    """List accesses for user"""
+    assert user_name, "required"
+    auth = _ensure_auth(auth, config)
+    data = {
+        "name": user_name,
+        "email": user_name,
+    }
+    url = auth.endpoint + "/" + 'arborist/user'
+    response = requests.post(
+        url, auth=auth, json=data
+    )
+    response.raise_for_status()
+    return response.json()

--- a/gen3_util/access/cli.py
+++ b/gen3_util/access/cli.py
@@ -1,0 +1,99 @@
+import click
+
+from gen3_util.access import user_ls, user_touch
+from gen3_util.access.requestor import ls, cat, touch, update
+from gen3_util.cli import CLIOutput
+from gen3_util.cli import NaturalOrderGroup
+from gen3_util.config import Config
+
+
+@click.group(name='access', cls=NaturalOrderGroup)
+@click.pass_obj
+def access_group(config: Config):
+    """Manage access requests."""
+    pass
+
+
+@access_group.command(name="ls")
+@click.option('--mine',  is_flag=True, show_default=True, default=False, help="List current user's requests. Otherwise, list all the requests the current user has access to see.")
+@click.pass_obj
+def access_ls(config: Config, mine: bool):
+    """List current user's requests."""
+    with CLIOutput(config=config) as output:
+        output.update(ls(config, mine))
+
+
+@access_group.command(name="cat")
+@click.argument('request_id')
+@click.pass_obj
+def access_cat(config: Config, request_id: str):
+    """Show details of a specific request.
+
+    \b
+    request_id (str): uuid of an existing request
+    """
+    with CLIOutput(config=config) as output:
+        output.update(cat(config, request_id))
+
+
+@access_group.command(name="touch")
+@click.argument('user_name')
+@click.argument('resource_path')
+@click.pass_obj
+def access_touch(config: Config,  user_name: str, resource_path: str):
+    """Show details of a specific request.
+
+    \b
+    user_name (str): user's email
+    resource_path (str): /programs/XXX/project/YYY
+
+    """
+    with CLIOutput(config=config) as output:
+        output.update(touch(config, resource_path))
+
+
+@access_group.command(name="update")
+@click.argument('request_id')
+@click.argument('status')
+@click.pass_obj
+def access_update(config: Config, request_id: str, status: str):
+    """Update a specific request.
+
+    \b
+    request_id (str): uuid of an existing request
+    status (str): new status see {ALLOWED_REQUEST_STATUSES}
+    """
+    with CLIOutput(config=config) as output:
+        output.update(update(config, request_id, status))
+
+
+@access_group.group(name="user")
+def access_user_group():
+    """Manage user access."""
+    pass
+
+
+@access_user_group.command(name="ls")
+@click.argument('user_name')
+@click.pass_obj
+def access_user_ls(config: Config, user_name: str):
+    """List current user's access.
+
+    \b
+    user_name: email of user
+    """
+    with CLIOutput(config=config) as output:
+        output.update(user_ls(config=config, user_name=user_name))
+
+
+@access_user_group.command(name="touch")
+@click.argument('user_name')
+@click.pass_obj
+def access_user_touch(config: Config, user_name: str):
+    """List current user's access.
+
+    \b
+    user_name: email of user
+    """
+    with CLIOutput(config=config) as output:
+        output.update(user_touch(config=config, user_name=user_name))

--- a/gen3_util/access/cli.py
+++ b/gen3_util/access/cli.py
@@ -1,6 +1,5 @@
 import click
 
-from gen3_util.access import user_ls, user_touch
 from gen3_util.access.requestor import ls, cat, touch, update
 from gen3_util.cli import CLIOutput
 from gen3_util.cli import NaturalOrderGroup
@@ -12,6 +11,37 @@ from gen3_util.config import Config
 def access_group(config: Config):
     """Manage access requests."""
     pass
+
+
+@access_group.command(name="touch")
+@click.argument('user_name')
+@click.argument('resource_path')
+@click.pass_obj
+def access_touch(config: Config,  user_name: str, resource_path: str):
+    """Create a request for read access.
+
+    \b
+    user_name (str): user's email
+    resource_path (str): /programs/XXX/project/YYY
+
+    """
+    with CLIOutput(config=config) as output:
+        output.update(touch(config, resource_path))
+
+
+@access_group.command(name="update")
+@click.argument('request_id')
+@click.argument('status')
+@click.pass_obj
+def access_update(config: Config, request_id: str, status: str):
+    """Update the request's approval workflow.
+
+    \b
+    request_id (str): uuid of an existing request
+    status (str): new status see {ALLOWED_REQUEST_STATUSES}
+    """
+    with CLIOutput(config=config) as output:
+        output.update(update(config, request_id, status))
 
 
 @access_group.command(name="ls")
@@ -34,66 +64,3 @@ def access_cat(config: Config, request_id: str):
     """
     with CLIOutput(config=config) as output:
         output.update(cat(config, request_id))
-
-
-@access_group.command(name="touch")
-@click.argument('user_name')
-@click.argument('resource_path')
-@click.pass_obj
-def access_touch(config: Config,  user_name: str, resource_path: str):
-    """Show details of a specific request.
-
-    \b
-    user_name (str): user's email
-    resource_path (str): /programs/XXX/project/YYY
-
-    """
-    with CLIOutput(config=config) as output:
-        output.update(touch(config, resource_path))
-
-
-@access_group.command(name="update")
-@click.argument('request_id')
-@click.argument('status')
-@click.pass_obj
-def access_update(config: Config, request_id: str, status: str):
-    """Update a specific request.
-
-    \b
-    request_id (str): uuid of an existing request
-    status (str): new status see {ALLOWED_REQUEST_STATUSES}
-    """
-    with CLIOutput(config=config) as output:
-        output.update(update(config, request_id, status))
-
-
-@access_group.group(name="user")
-def access_user_group():
-    """Manage user access."""
-    pass
-
-
-@access_user_group.command(name="ls")
-@click.argument('user_name')
-@click.pass_obj
-def access_user_ls(config: Config, user_name: str):
-    """List current user's access.
-
-    \b
-    user_name: email of user
-    """
-    with CLIOutput(config=config) as output:
-        output.update(user_ls(config=config, user_name=user_name))
-
-
-@access_user_group.command(name="touch")
-@click.argument('user_name')
-@click.pass_obj
-def access_user_touch(config: Config, user_name: str):
-    """List current user's access.
-
-    \b
-    user_name: email of user
-    """
-    with CLIOutput(config=config) as output:
-        output.update(user_touch(config=config, user_name=user_name))

--- a/gen3_util/access/requestor.py
+++ b/gen3_util/access/requestor.py
@@ -1,0 +1,63 @@
+from typing import List
+
+from pydantic import BaseModel
+
+from gen3_util.access import get_requests, get_request, create_request, update_request
+from gen3_util.config import Config, ensure_auth
+
+
+class LogAccess(BaseModel):
+    endpoint: str
+    """The commons url"""
+    requests: List[dict] = None
+    """List of requests"""
+    request: dict = None
+    """A single request"""
+
+
+def ls(config: Config, mine: bool) -> LogAccess:
+    """List requests."""
+    auth = ensure_auth(config.gen3.refresh_file)
+    requests = get_requests(auth=auth, mine=mine)
+    return LogAccess(**{
+        'endpoint': auth.endpoint,
+        'requests': [_ for _ in requests],
+    })
+
+
+def cat(config: Config, request_id: str) -> dict:
+    """Show a specific request requests."""
+    auth = ensure_auth(config.gen3.refresh_file)
+    requests = get_request(auth=auth, request_id=request_id)
+    return LogAccess(**{
+        'endpoint': auth.endpoint,
+        'requests': [_ for _ in requests],
+    })
+
+
+def touch(config: Config, resource_path: str) -> LogAccess:
+    """List requests."""
+    auth = ensure_auth(config.gen3.refresh_file)
+    request = create_request(auth=auth, resource_path=resource_path)
+    return LogAccess(**{
+        'endpoint': auth.endpoint,
+        'request': request,
+    })
+
+
+ALLOWED_REQUEST_STATUSES = """DRAFT SUBMITTED APPROVED SIGNED REJECTED""".split()
+
+
+def update(config: Config, request_id: str, status: str) -> LogAccess:
+    """List requests."""
+    assert request_id, "required"
+    assert status, "required"
+    status = status.upper()
+    assert status in ALLOWED_REQUEST_STATUSES, f"{status} not in {ALLOWED_REQUEST_STATUSES}"
+
+    auth = ensure_auth(config.gen3.refresh_file)
+    request = update_request(auth=auth, request_id=request_id, status=status)
+    return LogAccess(**{
+        'endpoint': auth.endpoint,
+        'request': request,
+    })

--- a/gen3_util/buckets/cli.py
+++ b/gen3_util/buckets/cli.py
@@ -8,7 +8,7 @@ from gen3_util.config import Config, ensure_auth
 @click.group(name='buckets', cls=NaturalOrderGroup)
 @click.pass_obj
 def bucket_group(config: Config):
-    """Manage Gen3 projects."""
+    """Manage Gen3 buckets."""
     pass
 
 

--- a/gen3_util/cli/__init__.py
+++ b/gen3_util/cli/__init__.py
@@ -17,11 +17,13 @@ def _common_options(self):
                                          envvar=f"{ENV_VARIABLE_PREFIX}_CONFIG",
                                          default=None,
                                          required=False,
+                                         show_default=True,
                                          help=f'Path to config file. {ENV_VARIABLE_PREFIX}_CONFIG'))
     self.params.insert(1,
                        click.core.Option(('--format', 'output_format'),
                                          envvar=f"{ENV_VARIABLE_PREFIX}_FORMAT",
-                                         default='text',
+                                         default='yaml',
+                                         show_default=True,
                                          type=click.Choice(['yaml', 'json', 'text'], case_sensitive=False),
                                          help=f'Result format. {ENV_VARIABLE_PREFIX}_FORMAT'))
 
@@ -30,13 +32,15 @@ def _common_options(self):
                        click.core.Option(('--cred', 'cred'),
                                          envvar="GEN3_API_KEY",
                                          default=None,
+                                         show_default=True,
                                          help='See https://uc-cdis.github.io/gen3-user-doc/appendices'
                                               '/api-gen3/#credentials-to-query-the-api. GEN3_API_KEY'))
 
     self.params.insert(3,
                        click.core.Option(('--state_dir', ),
                                          envvar=f"{ENV_VARIABLE_PREFIX}_STATE_DIR",
-                                         default='~/.gen3/gen3-util-state',
+                                         default='~/.gen3/gen3_util',
+                                         show_default=True,
                                          help=f'Directory for file transfer state {ENV_VARIABLE_PREFIX}_STATE_DIR'))
 
 

--- a/gen3_util/cli/cli.py
+++ b/gen3_util/cli/cli.py
@@ -5,6 +5,7 @@ import click
 import pkg_resources  # part of setuptools
 
 import gen3_util
+from gen3_util.access.cli import access_group
 from gen3_util.cli import StdNaturalOrderGroup
 from gen3_util.config.cli import config_group
 from gen3_util.files.cli import file_group
@@ -50,6 +51,7 @@ cli.add_command(project_group)
 cli.add_command(bucket_group)
 cli.add_command(meta_group)
 cli.add_command(file_group)
+cli.add_command(access_group)
 cli.add_command(config_group)
 
 

--- a/gen3_util/config.yaml
+++ b/gen3_util/config.yaml
@@ -2,3 +2,5 @@
 log:
   format: '%(asctime)s %(name)s %(levelname)s %(funcName)s:%(lineno)d %(message)s'
   level: INFO  # DEBUG, INFO, WARNING, ERROR
+output:
+  format: yaml

--- a/gen3_util/files/cli.py
+++ b/gen3_util/files/cli.py
@@ -13,7 +13,7 @@ from gen3_util.files.uploader import cp as upload
 @click.group(name='files', cls=NaturalOrderGroup)
 @click.pass_obj
 def file_group(config):
-    """Manage file buckets."""
+    """Manage file transfers."""
     pass
 
 
@@ -42,9 +42,9 @@ def files_cp(config: Config, from_: str, to_: str, worker_count: int, ignore_sta
              source_path: str, disable_progress_bar: bool):
     """Copy files to/from the project bucket.
 
-    Args:
-        from_: Source url or path
-        to_: Destination url or path
+    \b
+    from_: Source url or path
+    to_: Destination url or path
     """
 
     with CLIOutput(config=config) as output:

--- a/gen3_util/projects/lister.py
+++ b/gen3_util/projects/lister.py
@@ -1,3 +1,4 @@
+import json
 from typing import List
 
 from pydantic import BaseModel
@@ -17,6 +18,7 @@ def ls(config: Config):
     """List projects."""
     auth = ensure_auth(config.gen3.refresh_file)
     user = get_user(auth=auth)
+    print(json.dumps(user))
     return LogConfig(**{
         'endpoint': auth.endpoint,
         'projects': [_ for _ in user['authz'].keys() if _.startswith('/programs')],

--- a/gen3_util/projects/lister.py
+++ b/gen3_util/projects/lister.py
@@ -1,4 +1,3 @@
-import json
 from typing import List
 
 from pydantic import BaseModel
@@ -18,7 +17,6 @@ def ls(config: Config):
     """List projects."""
     auth = ensure_auth(config.gen3.refresh_file)
     user = get_user(auth=auth)
-    print(json.dumps(user))
     return LogConfig(**{
         'endpoint': auth.endpoint,
         'projects': [_ for _ in user['authz'].keys() if _.startswith('/programs')],

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 # testing
 pytest
+pytest-cov
 # syntax check
 flake8
 # syntax enforcer

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     # Versions should comply with PEP 440:
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.1',  # Required
+    version='0.0.2-rc1',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/tests/integration/test_access.py
+++ b/tests/integration/test_access.py
@@ -1,0 +1,62 @@
+import json
+
+from click.testing import CliRunner
+from gen3_util.cli.cli import cli
+
+
+def test_access_ls(caplog):
+    """Ensure we can ls access."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ['access', 'ls'])
+    assert result.exit_code == 0
+    expected_strings = ['OK']
+    for expected_string in expected_strings:
+        assert expected_string in result.output, f"Did not find {expected_string} in {expected_strings}"
+
+
+# def test_access_touch():
+#     """Ensure we detect missing input path."""
+#     runner = CliRunner()
+#     result = runner.invoke(cli, 'access touch bar@foo.com /programs/aced/project/MCF10A'.split())
+#     assert result.exit_code == 0
+#     expected_strings = ['OK', 'request_id']
+#     for expected_string in expected_strings:
+#         assert expected_string in result.output, f"Did not find {expected_string} in {expected_strings}"
+
+
+def test_access_workflow():
+    runner = CliRunner()
+    result = runner.invoke(cli, '--format json access touch bar@foo.com /programs/aced/project/MCF10A'.split())
+    assert result.exit_code == 0
+    expected_strings = ['OK', 'request_id']
+    for expected_string in expected_strings:
+        assert expected_string in result.output, f"Did not find {expected_string} in {expected_strings}"
+    request = json.loads(result.output)['request']
+    assert request['request_id'], "Missing request id"
+    request_id = request['request_id']
+    assert request['status'] == 'DRAFT', f"unexpected status {request['status']}"
+
+    print(f'--format json access access update {request_id} SUBMITTED')
+    result = runner.invoke(cli, f'--format json access update {request_id} SUBMITTED'.split())
+    assert result.exit_code == 0
+    expected_strings = ['OK', 'request_id']
+    for expected_string in expected_strings:
+        assert expected_string in result.output, f"Did not find {expected_string} in {expected_strings}"
+    request = json.loads(result.output)['request']
+    assert request['status'] == 'SUBMITTED', f"unexpected status {request['status']}"
+
+    result = runner.invoke(cli, f'--format json access update {request_id} APPROVED'.split())
+    assert result.exit_code == 0
+    expected_strings = ['OK', 'request_id']
+    for expected_string in expected_strings:
+        assert expected_string in result.output, f"Did not find {expected_string} in {expected_strings}"
+    request = json.loads(result.output)['request']
+    assert request['status'] == 'APPROVED', f"unexpected status {request['status']}"
+
+    result = runner.invoke(cli, f'--format json access update {request_id} SIGNED'.split())
+    assert result.exit_code == 0
+    expected_strings = ['OK', 'request_id']
+    for expected_string in expected_strings:
+        assert expected_string in result.output, f"Did not find {expected_string} in {expected_strings}"
+    request = json.loads(result.output)['request']
+    assert request['status'] == 'SIGNED', f"unexpected status {request['status']}"

--- a/tests/unit/test_meta.py
+++ b/tests/unit/test_meta.py
@@ -9,13 +9,13 @@ def test_import_from_directory():
     result = runner.invoke(cli, params)
     print(result.output)
     assert result.exit_code == 0
-    expected_strings = ['DocumentReference', "'size': 6013814", 'ResearchStudy', "'count': 1"]
+    expected_strings = ['DocumentReference', "size: 6013814", 'ResearchStudy', "count: 1"]
     for expected_string in expected_strings:
         assert expected_string in result.output, f"{expected_string} not found in {result.output}"
 
     result = runner.invoke(cli, 'meta validate tmp/foo'.split())
     print(result.output)
     assert result.exit_code == 0
-    expected_strings = ["'msg': 'OK'"]
+    expected_strings = ["msg: OK"]
     for expected_string in expected_strings:
         assert expected_string in result.output, f"{expected_string} not found in {result.output}"


### PR DESCRIPTION
This PR adds:
* `access` module that interfaces w/ Gen3's [requestor](https://github.com/uc-cdis/requestor), see tests/integration/test_access.py for simple workflow


#### Enables `User` and `Someone who makes access decisions`

> From Requestor's documentation

![image](https://github.com/uc-cdis/requestor/raw/master/docs/img/requestor_example_flow.png)


specifically:

* gen3_util access `touch` USER_NAME RESOURCE_PATH implements `Fill out access request form`
*  gen3_util access `update` REQUEST_ID STATUS implements `update access request status`
*  gen3_util access `ls` implements `send form data`



see https://github.com/uc-cdis/requestor/blob/master/docs/functionality_and_flow.md

---/--- 


```$ gen3_util access
Usage: gen3_util access [OPTIONS] COMMAND [ARGS]...

  Manage access requests.

Options:
  --help  Show this message and exit.

Commands:
  touch   Create a request for read access.
  update  Update the request's approval workflow.
  ls      List current user's requests.
  cat     Show details of a specific request.
```