### PR TITLE
Add initial support for removing files from a project

### DIFF
--- a/gen3_util/files/cli.py
+++ b/gen3_util/files/cli.py
@@ -173,7 +173,10 @@ def _manifest_rm(config: Config, project_id: str, object_id: str):
 
 
 @file_group.command(name="rm")
+@click.option('--object_id', default=None, required=True, show_default=True,
+              help="file UUID", envvar='OBJECT_ID')
 @click.pass_obj
-def files_rm(config: Config):
+def files_rm(config: Config, object_id: str):
     """Remove files from a project."""
-    rm(config)
+    with CLIOutput(config=config) as output:
+        output.update(rm(config, object_id))

--- a/gen3_util/files/remover.py
+++ b/gen3_util/files/remover.py
@@ -4,10 +4,9 @@ from gen3_util.config import Config, gen3_services
 
 def rm(config: Config, object_id: str = None):
     """Remove files."""
-    print_formatted(config, {'msg': 'file removal message goes here'})  # TODO implement
-    file_client, index_client, user, auth = gen3_services(config=config)
+    file_client, _, _, _ = gen3_services(config=config)
     if object_id:
         resp = file_client.delete_file_locations(object_id)
-        return resp
+        return {'response': resp.status_code, 'msg': resp.text}
 
     return None

--- a/gen3_util/files/remover.py
+++ b/gen3_util/files/remover.py
@@ -1,7 +1,13 @@
 from gen3_util.common import print_formatted
-from gen3_util.config import Config
+from gen3_util.config import Config, gen3_services
 
 
-def rm(config: Config):
+def rm(config: Config, object_id: str = None):
     """Remove files."""
     print_formatted(config, {'msg': 'file removal message goes here'})  # TODO implement
+    file_client, index_client, user, auth = gen3_services(config=config)
+    if object_id:
+        resp = file_client.delete_file_locations(object_id)
+        return resp
+
+    return None


### PR DESCRIPTION
## Overview

Adds initial support for removing a File from the Gen3 system.

Related to this Fence PR for deleting files from a non-AWS S3 endpoint
> https://github.com/uc-cdis/fence/pull/1127

## Tasks

- [ ] Add Sower job to remove file from ElasticSearch index
- [ ] Match Response code to existing response (e.g. `OK` for successful response)
- [ ] Add unit/integration tests

## Help Message

```sh
gen3_util files rm --help
Usage: gen3_util files rm [OPTIONS]

  Remove files from a project.

Options:
  --object_id TEXT  file UUID  [required]
  --help            Show this message and exit.
```

## Successful Response

```sh
gen3_util files rm --object_id <File DID>

response: 204    <--- Need to update this to match existing successful response ('OK')
```

## Unsuccessful Response

```
gen3_util files rm --object_id <File DID>

response: 500    <--- Need to update this to match existing failure response
msg: '{ "error": "service failure - try again later"}'
```