### PR TITLE
feature one project

### DIFF
--- a/gen3_util/access/requestor.py
+++ b/gen3_util/access/requestor.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import yaml
+from gen3.auth import Gen3Auth
 from pydantic import BaseModel
 
 from gen3_util.access import get_requests, get_request, create_request, update_request
@@ -47,9 +48,10 @@ def format_policy(policy: dict, project_id: str, user_name: str) -> dict:
     return policy
 
 
-def ls(config: Config, mine: bool, active: bool = False, username: str = None) -> LogAccess:
+def ls(config: Config, mine: bool, active: bool = False, username: str = None, auth: Gen3Auth = None) -> LogAccess:
     """List requests."""
-    auth = ensure_auth(profile=config.gen3.profile)
+    if not auth:
+        auth = ensure_auth(profile=config.gen3.profile)
     requests = get_requests(auth=auth, mine=mine, active=active, username=username)
     if not isinstance(requests, list):
         raise Exception(f"Unexpected response: {requests}")
@@ -88,10 +90,11 @@ def touch(config: Config, resource_path: str, user_name: str, roles: str) -> Log
     })
 
 
-def cp(config: Config, request: dict, revoke: bool = False) -> LogAccess:
+def cp(config: Config, request: dict, revoke: bool = False, auth: Gen3Auth = None) -> LogAccess:
     """List requests."""
 
-    auth = ensure_auth(profile=config.gen3.profile)
+    if not auth:
+        auth = ensure_auth(profile=config.gen3.profile)
 
     request = create_request(auth=auth, request=request, revoke=revoke)
     return LogAccess(**{
@@ -103,14 +106,16 @@ def cp(config: Config, request: dict, revoke: bool = False) -> LogAccess:
 ALLOWED_REQUEST_STATUSES = """DRAFT SUBMITTED APPROVED SIGNED REJECTED""".split()
 
 
-def update(config: Config, request_id: str, status: str) -> LogAccess:
+def update(config: Config, request_id: str, status: str, auth: Gen3Auth = None) -> LogAccess:
     """Update request."""
     assert request_id, "required"
     assert status, "required"
     status = status.upper()
     assert status in ALLOWED_REQUEST_STATUSES, f"{status} not in {ALLOWED_REQUEST_STATUSES}"
 
-    auth = ensure_auth(profile=config.gen3.profile)
+    if not auth:
+        auth = ensure_auth(profile=config.gen3.profile)
+
     request = update_request(auth=auth, request_id=request_id, status=status)
     return LogAccess(**{
         'endpoint': auth.endpoint,
@@ -174,8 +179,7 @@ def rm_user(config: Config, project_id: str, user_name: str) -> LogAccess:
     })
 
 
-# TODO Remove?
-def add_policies(config: Config, project_id: str) -> LogAccess:
+def add_policies(config: Config, project_id: str, auth: Gen3Auth = None) -> LogAccess:
     """Add policies to project. """
     # implement read from resource_path
     policies_ = []
@@ -189,11 +193,11 @@ def add_policies(config: Config, project_id: str) -> LogAccess:
     request_ids = []
     for policy in policies_:
         policy = format_policy(policy, project_id, user_name=None)
-        requests.append(cp(request=policy, config=config).request)
+        requests.append(cp(request=policy, config=config, auth=auth).request)
         request_ids.append(requests[-1]['request_id'])
 
-    commands = [f"gen3_util access update {request_id} SIGNED" for request_id in request_ids]
-    msg = f"Approve these requests to assign default policies to {project_id}"
+    commands = ['gen3_util access sign']
+    msg = f"An authorized user must approve these requests to assign default policies to {project_id}"
     return LogAccess(**{
         'requests': requests,
         'msg': msg,

--- a/gen3_util/access/submitter.py
+++ b/gen3_util/access/submitter.py
@@ -1,0 +1,25 @@
+
+from gen3.auth import Gen3Auth
+from gen3.submission import Gen3Submission
+
+from gen3_util import Config
+from gen3_util.config import ensure_auth
+
+
+def ensure_program_project(config: Config, project_id: str, auth: Gen3Auth = None) -> str:
+    """Ensure program and project exist in sheepdog.
+    """
+    if not auth:
+        auth = ensure_auth(profile=config.gen3.profile)
+    program, project = project_id.split('-')
+    submission = Gen3Submission(auth)
+    msgs = []
+    programs = [_.split('/')[-1] for _ in submission.get_programs()['links']]
+    if program not in programs:
+        submission.create_program({'name': program, 'type': 'program', 'dbgap_accession_number': program})
+        msgs.append(f"Created program: {program}")
+    projects = [_.split('/')[-1] for _ in submission.get_projects(program)['links']]
+    if project not in projects:
+        submission.create_project(program, {'code': project, 'type': 'project', "state": "open", "dbgap_accession_number": project})
+        msgs.append(f"Created project: {project}")
+    return ', '.join(msgs)

--- a/gen3_util/files/manifest.py
+++ b/gen3_util/files/manifest.py
@@ -244,7 +244,7 @@ def upload_files(config: Config, manifest_entries: list[dict], project_id: str, 
         json.dump(manifest_entries, manifest_file)
 
     cmd = f"gen3-client upload-multiple --manifest {manifest_path} --profile {profile} --upload-path {upload_path} --bucket {bucket_name} --numparallel {worker_count()}"
-    # print(f"Running: {cmd}", file=sys.stderr)
+    print(f"Running: {cmd}", file=sys.stderr)
     cmd = cmd.split()
     upload_results = subprocess.run(cmd)
     assert upload_results.returncode == 0, upload_results

--- a/gen3_util/meta/skeleton.py
+++ b/gen3_util/meta/skeleton.py
@@ -80,7 +80,7 @@ def study_metadata(config: Config, project_id: str, output_path: str, overwrite:
         print(f"Checking for existing records for project_id:{project_id}...", file=sys.stderr)
         nodes = meta_nodes(config, project_id, auth=auth)  # fetches document_ids by default
         existing_resource_ids = set([_['id'] for _ in nodes])
-        # print(f"Retrieved {len(existing_resource_ids)} existing records.", file=sys.stderr)
+        print(f"Retrieved {len(existing_resource_ids)} existing records.", file=sys.stderr)
 
     # get file client
     if source == 'indexd':

--- a/gen3_util/projects/cli.py
+++ b/gen3_util/projects/cli.py
@@ -3,7 +3,8 @@ import click
 from gen3_util.access.requestor import add_policies
 from gen3_util.cli import CLIOutput
 from gen3_util.cli import NaturalOrderGroup
-from gen3_util.config import Config
+from gen3_util.common import validate_project_id
+from gen3_util.config import Config, ensure_auth
 from gen3_util.projects.lister import ls
 from gen3_util.projects.remover import rm
 
@@ -23,7 +24,18 @@ def new_project(config: Config, project_id: str):
     """Creates project resource with default policies.
     """
     with CLIOutput(config=config) as output:
-        output.update(add_policies(config, project_id))
+        auth = ensure_auth(profile=config.gen3.profile)
+        msgs = validate_project_id(project_id)
+        if not msgs:
+            program, project = project_id.split('-')
+            projects = ls(config, auth=auth)
+            existing_project = [_ for _ in projects.projects if _.endswith(project)]
+            if len(existing_project) > 0:
+                msgs.append(f"Project already exists: {existing_project[0]}")
+            else:
+                output.update(add_policies(config, project_id, auth=auth))
+        if msgs:
+            output.update({'msg': ', '.join(msgs)})
 
 
 @project_group.command(name="ls")

--- a/gen3_util/projects/lister.py
+++ b/gen3_util/projects/lister.py
@@ -1,14 +1,15 @@
-
+from gen3.auth import Gen3Auth
 from gen3.submission import Gen3Submission
 
 from gen3_util.config import Config, ensure_auth
 from gen3_util.projects import ProjectSummaries, get_projects, ProjectSummary
 
 
-def ls(config: Config, resource_filter: str = None, msgs: list[str] = []):
+def ls(config: Config, resource_filter: str = None, msgs: list[str] = [], auth: Gen3Auth = None) -> ProjectSummaries:
     """List projects."""
 
-    auth = ensure_auth(profile=config.gen3.profile)
+    if not auth:
+        auth = ensure_auth(profile=config.gen3.profile)
     submission = Gen3Submission(auth)
 
     projects = get_projects(auth, submission)

--- a/tests/integration/test_access.py
+++ b/tests/integration/test_access.py
@@ -20,6 +20,7 @@ def test_access_ls(caplog):
 
 def test_access_touch_read_only():
     """Ensure we can add a user with default read-only access."""
+    # TODO - deprecate, see `gen3_util users add`
     runner = CliRunner()
     result = runner.invoke(cli, 'access touch bar@foo.com aced-Alcoholism'.split())
     assert result.exit_code == 0
@@ -30,6 +31,7 @@ def test_access_touch_read_only():
 
 def test_access_touch_roles():
     """Ensure we can add a user with specific roles."""
+    # TODO - deprecate, see `gen3_util users add user@example.com -w`
     runner = CliRunner()
     result = runner.invoke(cli, 'access touch bar@foo.com aced-Alcoholism --roles writer,reader '.split())
     assert result.exit_code == 0
@@ -40,6 +42,7 @@ def test_access_touch_roles():
 
 def test_access_touch_bad_email():
     """Ensure we catch invalid email."""
+    # TODO - deprecate, see `gen3_util users add user@example.com -w`
     runner = CliRunner()
     result = runner.invoke(cli, 'access touch barfoo.com aced-Alcoholism --roles storage_writer,file_uploader'.split())
     assert result.exit_code != 0
@@ -47,6 +50,7 @@ def test_access_touch_bad_email():
 
 def test_access_touch_bad_project_id():
     """Ensure we catch project id."""
+    # TODO - deprecate, see `gen3_util users add user@example.com -w`
     runner = CliRunner()
     result = runner.invoke(cli, 'access touch bar@foo.com aced-Alcoholism-XXX --roles storage_writer,file_uploader'.split())
     assert result.exit_code != 0
@@ -54,6 +58,7 @@ def test_access_touch_bad_project_id():
 
 def test_access_workflow(profile):
     """This access request in particular creates 409s if you run the test twice"""
+    # TODO - deprecate, see `gen3_util users add user@example.com -w`
     runner = CliRunner()
 
     user_name = str(uuid.uuid4())

--- a/tests/integration/test_meta.py
+++ b/tests/integration/test_meta.py
@@ -3,6 +3,7 @@ import pathlib
 import subprocess
 import uuid
 
+import pytest
 from click.testing import CliRunner
 
 from gen3_util.cli.cli import cli
@@ -165,14 +166,11 @@ def create_project_resource_in_arborist(project_id):
     result = runner.invoke(cli, f'--format json projects new --project_id {project_id}'.split())
     assert result.exit_code == 0, result.output
 
-    request = json.loads(result.output)
-    # get the `commands` convenience command lines to sign the requests
-    commands = request['commands']
-    for command in commands:
-        command = command.replace('gen3_util', '')
-        result = runner.invoke(cli, f'--format json {command}'.split())
-        print(result.output)
-        assert result.exit_code == 0
+    result = runner.invoke(cli, '--format json access sign'.split())
+    _, project = project_id.split('-')
+    print(result.output)
+    assert result.exit_code == 0
+    assert project in result.output, result.output
 
 
 def upload_manifest(project_id, profile):
@@ -216,3 +214,7 @@ def test_incremental_workflow(program, profile):
 
     # remove a file
     rm_file(file_ids[0], project_id, profile)
+
+    # should fail
+    with pytest.raises(AssertionError):
+        create_project_resource_in_arborist(project_id)


### PR DESCRIPTION
This PR:
  * checks if project exists when user requests `project new`
  * adds submission code to create_program, _project, `access sign` command

Documentation changes:
  * none: no new commands or options to gen3_util cli

Other dependencies:
  * when merged, we should remove program, project creation from [submission.meta_graph_load](https://github.com/ACED-IDP/submission/blob/626cbc23ccab78d71722632ec7f492e71cad365a/aced_submission/meta_graph_load.py#L301)
  * User who signs request must have sheepdog privileges
  

Test process:
```
# request a non existing project, that should work:
gen3_util projects new --project_id test-foobar18
# >>>  An authorized user must approve these requests to assign default policies to  test-foobar18

# request the same project name in another program
gen3_util projects new --project_id test2-foobar18
# >>> Project already exists: /programs/test/projects/foobar18

# signing the request should create project
gen3_util access sign
# >>> 'Signed 2 requests. Created project: foobar18'

# a new program should be created as well
gen3_util projects new --project_id foobar19-foobar19
gen3_util access sign
# >>> Signed 2 requests. Created program: foobar19, Created project: foobar19 


```
