### PR TITLE
Update cli.py

### DIFF
--- a/gen3_util/repo/cli.py
+++ b/gen3_util/repo/cli.py
@@ -38,7 +38,7 @@ from gen3_util.users.cli import users_group
 def cli(ctx, output_format, profile, version):
     """Gen3 Tracker: manage FHIR metadata and files."""
     if version:
-        _ = pkg_version('gen3-util')
+        _ = pkg_version('gen3-tracker')
         click.echo(_)
         ctx.exit()
 


### PR DESCRIPTION
Small fix to resolve the following error when running `g3t --version`:

```
➜ g3t --version
Traceback (most recent call last):
...
    raise PackageNotFoundError(name)
importlib.metadata.PackageNotFoundError: No package metadata was found for gen3-util
```