### PR TITLE
Add initial support for etags in manifest

### DIFF
--- a/docs/git-lite-workflow.md
+++ b/docs/git-lite-workflow.md
@@ -74,8 +74,9 @@ Options:
   --patient TEXT      fhir patient identifier
   --task_id TEXT         fhir task identifier
   --observation_id TEXT  fhir observation identifier
-  --md5 TEXT             MD5 sum, if not provided, will be calculated before
-                         upload
+  --md5 TEXT          MD5 sum, if not provided, will be calculated before
+                      upload unless etag is provided
+  --etag TEXT         ETag value, required for non-local files
 ```
 
 #### Migration of existing project data
@@ -102,9 +103,9 @@ Options:
   --patient TEXT      fhir patient identifier
   --task_id TEXT         fhir task identifier
   --observation_id TEXT  fhir observation identifier
-  --md5 TEXT             MD5 sum, if not provided, will be calculated before
-                         upload
-
+  --md5 TEXT          MD5 sum, if not provided, will be calculated before
+                      upload unless etag is provided
+  --etag TEXT         ETag value, required for non-local files
 ```
 
 ### Create metadata files

--- a/gen3_util/access/policies/add-user-write.yaml
+++ b/gen3_util/access/policies/add-user-write.yaml
@@ -5,6 +5,3 @@ policies:
 # data uploader
 - policy_id: data_upload
   username:
-# jobs writer
-- policy_id: mds_gateway
-  username:

--- a/gen3_util/files/cli.py
+++ b/gen3_util/files/cli.py
@@ -114,7 +114,7 @@ def manifest_put_cli(config: Config, path: str, project_id: str, md5: str,
                 except ValueError:
                     modified = click.DateTime()(modified)
 
-            _ = manifest_put(config, local_path, project_id=project_id, md5=md5, size=size, modified=modified)
+            _ = manifest_put(config, local_path, project_id=project_id, hash=md5, size=size, modified=modified)
 
             _['observation_id'] = observation
             _['patient_id'] = patient

--- a/gen3_util/files/cli.py
+++ b/gen3_util/files/cli.py
@@ -117,7 +117,11 @@ def manifest_put_cli(config: Config, path: str, project_id: str, md5: str, etag:
                 except ValueError:
                     modified = click.DateTime()(modified)
 
-            _ = manifest_put(config, local_path, project_id=project_id, hash=md5, size=size, modified=modified)
+            _ = {}
+            if etag is not None:
+                _ = manifest_put(config, local_path, project_id=project_id, hash=etag, hash_type='etag', size=size, modified=modified)
+            else:
+                _ = manifest_put(config, local_path, project_id=project_id, hash=md5, size=size, modified=modified)
 
             _['observation_id'] = observation
             _['patient_id'] = patient

--- a/gen3_util/files/manifest.py
+++ b/gen3_util/files/manifest.py
@@ -55,7 +55,7 @@ def put(config: Config, file_name: str, project_id: str, hash: str, hash_type: s
         if hash_type not in ['md5', 'etag']:
             raise Exception(f"hash_type {hash_type} is not supported")
         if hash_type == 'etag' and not hash:
-            raise Exception(f"hash_type {hash_type} not provided")
+            raise Exception(f"etag value not provided")
         if hash_type == 'md5' and not hash:
             hash = md5sum(file)
         if not size:

--- a/gen3_util/files/middleware.py
+++ b/gen3_util/files/middleware.py
@@ -8,7 +8,7 @@ from gen3_util.meta.skeleton import transform_manifest_to_indexd_keys
 from gen3_util.files.lister import ls
 
 
-def files_ls_driver(config: Config, object_id: str, project_id: str, specimen: str, patient: str, observation: str, task: str, md5: str, is_metadata: bool, is_snapshot: bool, long: bool):
+def files_ls_driver(config: Config, object_id: str, project_id: str, specimen: str, patient: str, observation: str, task: str, md5: str, etag: str, is_metadata: bool, is_snapshot: bool, long: bool):
     """List uploaded files in a project bucket."""
 
     if not project_id:
@@ -18,12 +18,17 @@ def files_ls_driver(config: Config, object_id: str, project_id: str, specimen: s
             _ = to_metadata_dict(
                 is_metadata=is_metadata,
                 is_snapshot=is_snapshot,
-                md5=md5,
                 observation=observation,
                 patient=patient,
                 project_id=project_id,
                 specimen=specimen,
                 task=task)
+            if md5 is not None:
+                _['md5'] = md5
+            elif etag is not None:
+                _['etag'] = etag
+            else:
+                raise ValueError("Unsupported hash type")
             _ = transform_manifest_to_indexd_keys(_)
             results = ls(config, object_id=object_id, metadata=_)
             if not long:

--- a/gen3_util/meta/skeleton.py
+++ b/gen3_util/meta/skeleton.py
@@ -42,10 +42,16 @@ def update_document_reference(document_reference, index_record):
     document_reference.date = index_record['created_date']
 
     attachment = Attachment()
+    hash_type = ''
+    if 'etag' in index_record['hashes']:
+        hash_type = 'etag'
+    else:
+        hash_type = 'md5'
+
     attachment.extension = [
         {
-            "url": "http://aced-idp.org/fhir/StructureDefinition/md5",
-            "valueString": index_record['hashes']['md5']
+            "url": f"http://aced-idp.org/fhir/StructureDefinition/{hash_type}",
+            "valueString": index_record['hashes'][hash_type]
         },
         {
             "url": "http://aced-idp.org/fhir/StructureDefinition/source_path",

--- a/gen3_util/meta/skeleton.py
+++ b/gen3_util/meta/skeleton.py
@@ -185,8 +185,14 @@ def transform_manifest_to_indexd(_: dict, project_id: str) -> dict:
     _['metadata']['project_id'] = project_id
     _['created_date'] = _['metadata']['modified']
     del _['metadata']['modified']
-    _['hashes'] = {'md5': _['metadata']['md5']}
-    del _['metadata']['md5']
+    if 'etag' in _['metadata']:
+        _['hashes'] = {'etag': _['metadata']['etag']}
+        del _['metadata']['etag']
+    elif 'md5' in _['metadata']:
+        _['hashes'] = {'md5': _['metadata']['md5']}
+        del _['metadata']['md5']
+    else:
+        raise ValueError(f"No supported hash found in {_}")
     _['file_name'] = _['metadata']['file_name']
     del _['metadata']['file_name']
     _['size'] = _['metadata']['size']

--- a/gen3_util/repo/cli.py
+++ b/gen3_util/repo/cli.py
@@ -461,7 +461,7 @@ utilities_group.add_command(users_group)
 @click.pass_obj
 def log_cli(config: Config):
     """List metadata files"""
-    files_ls_driver(config, object_id=None, project_id=None, specimen=None, patient=None, observation=None, task=None, is_metadata=True, md5=None, is_snapshot=False, long=False)
+    files_ls_driver(config, object_id=None, project_id=None, specimen=None, patient=None, observation=None, task=None, is_metadata=True, md5=None, etag=None, is_snapshot=False, long=False)
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_commit.py
+++ b/tests/integration/test_commit.py
@@ -241,7 +241,7 @@ def test_bundle(config, program, tmp_path):
     with open(local_path, 'w') as fp:
         fp.write(''.join(random.choices(string.ascii_letters, k=file_size)))
 
-    _ = gen3_util.files.manifest.put(config, str(local_path), project_id=project_id, md5=None)
+    _ = gen3_util.files.manifest.put(config, str(local_path), project_id=project_id, hash=None)
     _['patient_id'] = "P1"
     gen3_util.files.manifest.save(config, project_id, [_])
 

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -9,7 +9,7 @@ def test_put(test_files_directory, pattern='**/*'):
     for file in input_path.glob(pattern):
         if any([file.is_dir(), file.is_symlink()]):
             continue
-        _ = put(file_name=str(file), project_id=project_id, config=None, md5=None)
+        _ = put(file_name=str(file), project_id=project_id, config=None, hash=None)
         assert _['object_id'], f"object_id is missing for {file}"
         assert _['md5'], f"md5 is missing for {file}"
         assert _['mime_type'], f"mime_type is missing for {file}"

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -1,4 +1,6 @@
 import pathlib
+
+import pytest
 from gen3_util.files.manifest import put
 
 
@@ -12,6 +14,31 @@ def test_put(test_files_directory, pattern='**/*'):
         _ = put(file_name=str(file), project_id=project_id, config=None, hash=None)
         assert _['object_id'], f"object_id is missing for {file}"
         assert _['md5'], f"md5 is missing for {file}"
+        assert _['mime_type'], f"mime_type is missing for {file}"
+        assert _['size'], f"file_name is missing for {file}"
+        assert _['file_name'], f"file_name is missing for {file}"
+
+def test_import_missing_etag(test_files_directory, pattern='**/*'):
+    """Test manifest put."""
+    input_path = pathlib.Path(test_files_directory)
+    project_id = 'test-project'
+    for file in input_path.glob(pattern):
+        if any([file.is_dir(), file.is_symlink()]):
+            continue
+        with pytest.raises(Exception) as excinfo:
+            _ = put(file_name=str(file), project_id=project_id, config=None, hash=None, hash_type='etag')
+            assert "etag value not provided" in str(excinfo.value)
+
+def test_import(test_files_directory, pattern='**/*'):
+    """Test manifest put."""
+    input_path = pathlib.Path(test_files_directory)
+    project_id = 'test-project'
+    for file in input_path.glob(pattern):
+        if any([file.is_dir(), file.is_symlink()]):
+            continue
+        _ = put(file_name=str(file), project_id=project_id, config=None, hash='123-a', hash_type='etag')
+        assert _['object_id'], f"object_id is missing for {file}"
+        assert _['etag'] == '123-a', f"etag is missing for {file}"
         assert _['mime_type'], f"mime_type is missing for {file}"
         assert _['size'], f"file_name is missing for {file}"
         assert _['file_name'], f"file_name is missing for {file}"


### PR DESCRIPTION
Work in progress — starts to resolve #68 by adding initial support for using the etag hash of an S3 object to upload to indexd.

This PR was used to successfully import two projects (GDC-Lung and GDC-ESCA) based on the etags retrieved from a remote S3 endpoint using the `mc` client: 

```sh
➜ mc stat -r ceph/gdc-lung --json
```