### PR TITLE
Fix/pull from meta

### DIFF
--- a/gen3_util/repo/cli.py
+++ b/gen3_util/repo/cli.py
@@ -332,16 +332,7 @@ def pull_cli(config: Config, meta: bool, specimen: str, patient: str, task: str,
                 md5=md5, observation=observation, patient=patient, specimen=specimen, task=task
             )
 
-            logs = pull_files(
-                config=config,
-                manifest_name=manifest_name,
-                original_path=original_path,
-                path=path,
-                auth=auth,
-                extra_metadata=transform_manifest_to_indexd_keys(metadata_dict),
-                path_filter=path_filter
-            )
-
+            logs = []
             if meta:
                 snapshot_manifest = find_latest_snapshot(auth, config)
                 download_unzip_snapshot_meta(
@@ -352,6 +343,16 @@ def pull_cli(config: Config, meta: bool, specimen: str, patient: str, task: str,
                     original_path=original_path,
                     extract_to=path
                 )
+
+            logs = pull_files(
+                config=config,
+                manifest_name=manifest_name,
+                original_path=original_path,
+                path=path,
+                auth=auth,
+                extra_metadata=transform_manifest_to_indexd_keys(metadata_dict),
+                path_filter=path_filter
+            )
 
             output.update({'logs': logs})
 

--- a/gen3_util/repo/puller.py
+++ b/gen3_util/repo/puller.py
@@ -1,31 +1,19 @@
 import json
-import os
 import pathlib
 import subprocess
 import sys
 
-from gen3_util.files.lister import ls
+from gen3_util.common import read_ndjson_file
 from gen3_util.files.manifest import worker_count
-
-from wcmatch import glob
-from urllib.parse import urlparse
-import socket
 
 
 def pull_files(config, auth, manifest_name, original_path, path, extra_metadata={}, path_filter=None):
-    """Pull files from a Gen3 commons."""
+    """Pull files from a Gen3 based on current METADATA"""
     logs = []
-    # get all files from indexd
-    metadata = dict(extra_metadata | {'project_id': config.gen3.project_id})
-    results = ls(config=config, metadata=metadata, auth=auth)
-    records = 'records' in results and results['records'] or []
-    records = sorted(records, key=lambda d: d['size'])
-
     # create a manifest
-    if path_filter:
-        records = [_ for _ in records if glob.globmatch(_['file_name'], path_filter, flags=glob.G)]
-    # download files using the manifest created above
-    manifest = [{'object_id': _['did']} for _ in records if 'is_metadata' not in _['metadata'] and not _['metadata'].get('no_bucket', False) == 'true']
+    manifest = []
+    for _ in read_ndjson_file(pathlib.Path('META/DocumentReference.ndjson')):
+        manifest.append({'object_id': _['did']})
 
     data_path = pathlib.Path(path)
     if len(manifest) > 0:
@@ -41,40 +29,40 @@ def pull_files(config, auth, manifest_name, original_path, path, extra_metadata=
     else:
         logs.append(f"No files to download for {config.gen3.project_id}")
 
-    manifest = [{'object_id': _['did'], 'file_name': _['file_name'], 'urls': _['urls']} for _ in records if _['metadata'].get('no_bucket', False)]
-    if len(manifest) > 0:
-        hostname = socket.gethostname()
-        files_for_scp = []
-        files_for_symlink = []
-        for _ in manifest:
-            for url in _['urls']:
-                parse_result = urlparse(url)
-                if parse_result.scheme == 'scp':
-                    if parse_result.netloc == hostname:
-                        files_for_symlink.append(_)
-                    else:
-                        files_for_scp.append(_)
-
-        # print(f"SCP files {files_for_scp}", file=sys.stderr)
-        for _ in files_for_scp:
-            for url in _['urls']:
-                if 'scp' not in url:
-                    continue
-                cmd = f"scp {url} {data_path}"
-                logs.append(cmd)
-                # download_results = subprocess.run(cmd.split(), capture_output=False, stdout=sys.stderr)
-                # assert download_results.returncode == 0, f"SCP failed {download_results}"
-            logs.append(f"There are {len(files_for_scp)} files available for scp")
-        # print(f"Symlink files {files_for_symlink}", file=sys.stderr)
-        for _ in files_for_symlink:
-            for url in _['urls']:
-                if 'scp' not in url:
-                    continue
-                pathlib.Path(_['file_name']).parent.mkdir(parents=True, exist_ok=True)
-                os.symlink(urlparse(url).path, _['file_name'])
-            logs.append(f"Symlinked {len(files_for_symlink)} files.")
-    else:
-        logs.append(f"No files to symlink or scp for {config.gen3.project_id}")
+    # manifest = [{'object_id': _['did'], 'file_name': _['file_name'], 'urls': _['urls']} for _ in records if _['metadata'].get('no_bucket', False)]
+    # if len(manifest) > 0:
+    #     hostname = socket.gethostname()
+    #     files_for_scp = []
+    #     files_for_symlink = []
+    #     for _ in manifest:
+    #         for url in _['urls']:
+    #             parse_result = urlparse(url)
+    #             if parse_result.scheme == 'scp':
+    #                 if parse_result.netloc == hostname:
+    #                     files_for_symlink.append(_)
+    #                 else:
+    #                     files_for_scp.append(_)
+    #
+    #     # print(f"SCP files {files_for_scp}", file=sys.stderr)
+    #     for _ in files_for_scp:
+    #         for url in _['urls']:
+    #             if 'scp' not in url:
+    #                 continue
+    #             cmd = f"scp {url} {data_path}"
+    #             logs.append(cmd)
+    #             # download_results = subprocess.run(cmd.split(), capture_output=False, stdout=sys.stderr)
+    #             # assert download_results.returncode == 0, f"SCP failed {download_results}"
+    #         logs.append(f"There are {len(files_for_scp)} files available for scp")
+    #     # print(f"Symlink files {files_for_symlink}", file=sys.stderr)
+    #     for _ in files_for_symlink:
+    #         for url in _['urls']:
+    #             if 'scp' not in url:
+    #                 continue
+    #             pathlib.Path(_['file_name']).parent.mkdir(parents=True, exist_ok=True)
+    #             os.symlink(urlparse(url).path, _['file_name'])
+    #         logs.append(f"Symlinked {len(files_for_symlink)} files.")
+    # else:
+    #     logs.append(f"No files to symlink or scp for {config.gen3.project_id}")
 
     # logs.append(f"Downloaded {len(manifest)} files to {data_path.relative_to(original_path)}")
     return logs

--- a/gen3_util/repo/puller.py
+++ b/gen3_util/repo/puller.py
@@ -13,7 +13,7 @@ def pull_files(config, auth, manifest_name, original_path, path, extra_metadata=
     # create a manifest
     manifest = []
     for _ in read_ndjson_file(pathlib.Path('META/DocumentReference.ndjson')):
-        manifest.append({'object_id': _['did']})
+        manifest.append({'object_id': _['id']})
 
     data_path = pathlib.Path(path)
     if len(manifest) > 0:


### PR DESCRIPTION
This fix changes the way the pull command works.  Instead of using indexd records as the source of truth, it uses the local META/DocumentReferences.ndjson

Released as `pip install gen3-tracker==0.0.3rc9`