### PR TITLE
fix/create_id

### DIFF
--- a/gen3_tracker/__init__.py
+++ b/gen3_tracker/__init__.py
@@ -13,7 +13,7 @@ from click import Context, Command
 from pydantic import BaseModel, field_validator
 
 
-ACED_NAMESPACE = uuid.uuid3(uuid.NAMESPACE_DNS, 'aced-idp.org')
+ACED_NAMESPACE = uuid.uuid3(uuid.NAMESPACE_DNS, b'aced-idp.org')
 ENV_VARIABLE_PREFIX = 'G3T_'
 
 FILE_TRANSFER_METHODS = {

--- a/gen3_tracker/common/__init__.py
+++ b/gen3_tracker/common/__init__.py
@@ -319,9 +319,8 @@ def create_id(resource, project_id) -> str:
     from gen3_tracker import ACED_NAMESPACE
     assert resource, "resource required"
     assert project_id, "project_id required"
-    # identifier string is not unique when it complies with FHIR server. Using something else
-    # identifier_string = identifier_to_string(resource.identifier)
-    return str(uuid.uuid5(ACED_NAMESPACE, f"{project_id}/{resource.resource_type}/{resource}"))
+    identifier_string = identifier_to_string(resource.identifier)
+    return str(uuid.uuid5(ACED_NAMESPACE, f"{project_id}/{resource.resource_type}/{identifier_string}"))
 
 
 class Commit(BaseModel):

--- a/gen3_tracker/git/__init__.py
+++ b/gen3_tracker/git/__init__.py
@@ -1,13 +1,12 @@
 import json
 import logging
+import mimetypes
 import multiprocessing
 import os
 import pathlib
-import re
 import subprocess
 import time
 import typing
-import uuid
 import zipfile
 from abc import abstractmethod
 from datetime import datetime
@@ -21,11 +20,7 @@ from fhir.resources.attachment import Attachment
 from gen3.auth import Gen3Auth
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from gen3_tracker import ACED_NAMESPACE
-from gen3_tracker.common import ACCEPTABLE_HASHES, parse_iso_tz_date
-
-import mimetypes
-
+from gen3_tracker.common import ACCEPTABLE_HASHES, parse_iso_tz_date, create_object_id
 
 # constants ---------------------------------------------------------------------
 INIT_MESSAGE = 'Initializing a new repository...'
@@ -103,13 +98,7 @@ class DVCItem(BaseModel):
         """ create a unique did for this object within a project"""
         assert self.path, 'path is required'
 
-        def _normalize_file_url(path: str) -> str:
-            """Strip leading ./ and file:/// from file urls."""
-            path = re.sub(r'^file:\/\/\/', '', path)
-            path = re.sub(r'^\.\/', '', path)
-            return path
-
-        self.object_id = str(uuid.uuid5(ACED_NAMESPACE, project_id + f"::{_normalize_file_url(self.path)}"))
+        self.object_id = create_object_id(self.path, project_id)
         return self.object_id
 
 

--- a/gen3_tracker/git/cli.py
+++ b/gen3_tracker/git/cli.py
@@ -325,8 +325,9 @@ def status(config):
 @click.option('--re-run', show_default=True, default=False, is_flag=True, help='Re-run the last publish step')
 @click.option('--fhir-server', show_default=True, default=False, is_flag=True, help='Push data in META directory to FHIR Server. Whatever FHIR data that exists in META dir will be upserted into the fhir server')
 @click.option('--debug', is_flag=True)
+@click.option('--skip_validate', is_flag=True, help='Skip validation of the metadata')
 @click.pass_context
-def push(ctx, step: str, transfer_method: str, overwrite: bool, re_run: bool, wait: bool, dry_run: bool, fhir_server: bool, debug: bool):
+def push(ctx, step: str, transfer_method: str, overwrite: bool, re_run: bool, wait: bool, dry_run: bool, fhir_server: bool, debug: bool, skip_validate: bool):
     """Push changes to the remote repository.
     \b
     steps:
@@ -354,6 +355,9 @@ def push(ctx, step: str, transfer_method: str, overwrite: bool, re_run: bool, wa
         try:
             with Halo(text='Checking', spinner='line', placement='right', color='white'):
                 run_command("g3t status")
+                if not skip_validate:
+                    run_command("g3t meta validate", no_capture=True)
+
         except Exception as e:
             click.secho("Please correct issues before pushing.", fg=ERROR_COLOR, file=sys.stderr)
             click.secho(str(e), fg=ERROR_COLOR, file=sys.stderr)

--- a/gen3_tracker/meta/skeleton.py
+++ b/gen3_tracker/meta/skeleton.py
@@ -155,12 +155,15 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
     _ = f'Specimen/{specimen_id}'
     if _ in meta_index:
         specimen = meta_index[_]
+
     _ = f'Patient/{patient_id}'
     if _ in meta_index:
         patient = meta_index[_]
+
     _ = f'Task/{task_id}'
     if _ in meta_index:
         task = meta_index[_]
+
     _ = f'Observation/{observation_id}'
     if _ in meta_index:
         observation = meta_index[_]
@@ -182,6 +185,7 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
             Identifier(value=project_id, system=_get_system(project_id, project_id=project_id),
                        use='official')]
         research_study.id = create_id(research_study, project_id)
+        research_study.id = create_id(research_study, project_id)
 
     if not patient and patient_identifier:
         patient = Patient()
@@ -195,6 +199,7 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
         )
         research_subject.identifier = [Identifier(value=patient_identifier, system=_get_system(patient_identifier, project_id=project_id), use='official')]
         research_subject.id = create_id(research_subject, project_id)
+        patient_id = patient.id
 
     if not observation and observation_identifier:
         observation = Observation(status='final', code={'text': 'unknown'})
@@ -202,8 +207,7 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
         observation.id = create_id(observation, project_id)
 
         assert patient, "patient required for observation"
-        observation.subject = {'reference': f"Patient/{patient.id}"}
-        patient_id = patient.id
+        observation.subject = {'reference': f"Patient/{patient_id}"}
 
     if not specimen and specimen_identifier:
 
@@ -217,7 +221,7 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
         specimen_id = specimen.id
 
         assert patient, "patient required for specimen"
-        specimen.subject = {'reference': f"Patient/{patient.id}"}
+        specimen.subject = {'reference': f"Patient/{patient_id}"}
 
     if not task and task_identifier:
         task = Task(intent='unknown', status='completed')

--- a/gen3_tracker/meta/skeleton.py
+++ b/gen3_tracker/meta/skeleton.py
@@ -20,7 +20,7 @@ from fhir.resources.specimen import Specimen
 from fhir.resources.task import Task, TaskOutput, TaskInput
 
 from gen3_tracker import ACED_NAMESPACE
-from gen3_tracker.common import create_id, EmitterContextManager
+from gen3_tracker.common import create_resource_id, EmitterContextManager
 from gen3_tracker.git import DVC, run_command, dvc_data
 
 
@@ -184,13 +184,12 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
         research_study.identifier = [
             Identifier(value=project_id, system=_get_system(project_id, project_id=project_id),
                        use='official')]
-        research_study.id = create_id(research_study, project_id)
-        research_study.id = create_id(research_study, project_id)
+        research_study.id = create_resource_id(research_study, project_id)
 
     if not patient and patient_identifier:
         patient = Patient()
         patient.identifier = [Identifier(value=patient_identifier, system=_get_system(patient_identifier, project_id=project_id), use='official')]
-        patient.id = create_id(patient, project_id)
+        patient.id = create_resource_id(patient, project_id)
 
         research_subject = ResearchSubject(
             status='active',
@@ -198,13 +197,13 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
             subject={'reference': f"Patient/{patient.id}"}
         )
         research_subject.identifier = [Identifier(value=patient_identifier, system=_get_system(patient_identifier, project_id=project_id), use='official')]
-        research_subject.id = create_id(research_subject, project_id)
+        research_subject.id = create_resource_id(research_subject, project_id)
         patient_id = patient.id
 
     if not observation and observation_identifier:
         observation = Observation(status='final', code={'text': 'unknown'})
         observation.identifier = [Identifier(value=observation_identifier, system=_get_system(observation_identifier, project_id=project_id), use='official')]
-        observation.id = create_id(observation, project_id)
+        observation.id = create_resource_id(observation, project_id)
 
         assert patient, "patient required for observation"
         observation.subject = {'reference': f"Patient/{patient_id}"}
@@ -217,7 +216,7 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
 
         specimen = Specimen()
         specimen.identifier = [Identifier(value=specimen_identifier, system=_get_system(specimen_identifier, project_id=project_id), use='official')]
-        specimen.id = create_id(specimen, project_id)
+        specimen.id = create_resource_id(specimen, project_id)
         specimen_id = specimen.id
 
         assert patient, "patient required for specimen"
@@ -227,7 +226,7 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
         task = Task(intent='unknown', status='completed')
         task.identifier = [Identifier(value=task_identifier, system=_get_system(task_identifier, project_id=project_id),
                                       use='official')]
-        task.id = create_id(task, project_id)
+        task.id = create_resource_id(task, project_id)
         task_id = task.id
 
     # create relationships
@@ -306,7 +305,7 @@ def update_meta_files(dry_run=False, project_id=None) -> list[str]:
         bundle = Bundle(type='transaction', timestamp=now)
 
         bundle.identifier = Identifier(value=project_id, system="https://aced-idp.org/project_id", use='official')
-        bundle.id = create_id(bundle, project_id)
+        bundle.id = create_resource_id(bundle, project_id)
 
         bundle.entry = []
         outcome = OperationOutcome(issue=[{'severity': 'warning', 'code': 'processing', 'diagnostics': 'Meta data items no longer in study.'}])

--- a/pre-commit-tests.sh
+++ b/pre-commit-tests.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 pytest tests/unit
+# if running into problems w/ tests/unit/meta, see https://github.com/ACED-IDP/gen3_util/pull/99#discussion_r1788453747

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,33 @@
+import pathlib
+
+from click.testing import CliRunner, Result
+
+from gen3_tracker.cli import cli
+
+
+def run(runner: CliRunner, args: list[str], expected_output: list[str] = [], expected_exit_code: int = 0, expected_files: list[pathlib.Path] = []) -> Result:
+    """Run a command and check the output, exit code and expected files."""
+    if isinstance(args, str):
+        args = args.split()
+    if isinstance(expected_output, str):
+        expected_output = expected_output.splitlines()
+    if isinstance(expected_files, pathlib.Path):
+        expected_files = [expected_files]
+    expected_files = [pathlib.Path(_) for _ in expected_files]
+
+    print('------------------------------------------------------------')
+    print("g3t " + " ".join(args))
+    result = runner.invoke(cli, args)
+    print("result.stdout", result.stdout)
+    print("result.output", result.output)
+    print("result.exception", result.exception)
+    print("CWD", pathlib.Path.cwd())
+    assert result.exit_code == expected_exit_code, f"g3t {' '.join(args)} exit_code: {result.exit_code}, expected: {expected_exit_code}"
+    for line in expected_output:
+        assert line in result.output, f"output: {result.output}, expected: {expected_output}"
+        print(f"{line} found in output.")
+    for file in expected_files:
+        assert file.exists(), f"{file} does not exist."
+        print(f"{file} exists.")
+
+    return result

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,35 +1,7 @@
-import pathlib
-from click.testing import CliRunner, Result
 import requests
 
-from gen3_tracker.cli import cli
 from gen3_tracker.config import ensure_auth, default
 from gen3.query import Gen3Query
-
-
-def run(runner: CliRunner, args: list[str], expected_output: list[str] = [], expected_exit_code: int = 0, expected_files: list[pathlib.Path] = []) -> Result:
-    """Run a command and check the output, exit code and expected files."""
-    if isinstance(args, str):
-        args = args.split()
-    if isinstance(expected_output, str):
-        expected_output = expected_output.splitlines()
-    if isinstance(expected_files, pathlib.Path):
-        expected_files = [expected_files]
-    expected_files = [pathlib.Path(_) for _ in expected_files]
-
-    print('------------------------------------------------------------')
-    print("g3t " + " ".join(args))
-    result = runner.invoke(cli, args)
-    print(result.stdout)
-    assert result.exit_code == expected_exit_code, f"exit_code: {result.exit_code}, expected: {expected_exit_code}"
-    for line in expected_output:
-        assert line in result.output, f"output: {result.output}, expected: {expected_output}"
-        print(f"{line} found in output.")
-    for file in expected_files:
-        assert file.exists(), f"{file} does not exist."
-        print(f"{file} exists.")
-
-    return result
 
 
 def validate_document_in_grip(did: str, auth=None, project_id=None):

--- a/tests/integration/test_bucket_import.py
+++ b/tests/integration/test_bucket_import.py
@@ -1,7 +1,7 @@
 import json
 import pathlib
 
-from tests.integration import run
+from tests import run
 from click.testing import CliRunner
 import pytest
 

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -3,7 +3,7 @@ import pathlib
 from fhir.resources.bundle import Bundle
 
 from gen3_tracker.common import read_ndjson_file
-from tests.integration import run
+from tests import run
 from click.testing import CliRunner
 
 

--- a/tests/integration/test_end_to_end_workflow.py
+++ b/tests/integration/test_end_to_end_workflow.py
@@ -6,7 +6,8 @@ from click.testing import CliRunner
 
 from gen3_tracker.config import ensure_auth, default
 from gen3_tracker.git import DVC, run_command
-from tests.integration import run, validate_document_in_elastic, validate_document_in_grip
+from tests.integration import validate_document_in_elastic, validate_document_in_grip
+from tests import run
 
 
 # @pytest.mark.skip(reason="dataframer is not currently operational for adding single file use case")

--- a/tests/unit/meta/conftest.py
+++ b/tests/unit/meta/conftest.py
@@ -1,0 +1,26 @@
+import uuid
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Fixture for creating a CliRunner instance."""
+    return CliRunner()
+
+
+@pytest.fixture
+def program() -> str:
+    return "cbds"
+
+
+@pytest.fixture
+def project() -> str:
+    project = uuid.uuid4().hex.replace('-', '_')
+    return project
+
+
+@pytest.fixture
+def project_id(program, project) -> str:
+    project_id = f"{program}-{project}"
+    return project_id

--- a/tests/unit/meta/test_meta.py
+++ b/tests/unit/meta/test_meta.py
@@ -1,0 +1,122 @@
+import os
+import pathlib
+
+import yaml
+from click.testing import CliRunner
+
+import gen3_tracker.config
+from gen3_tracker.git import run_command
+from tests import run
+
+
+def test_assert_object_id_invalid_on_project_id_change(runner: CliRunner, project_id, tmp_path: pathlib.Path) -> None:
+    """Test object_id validation command."""
+    # change to the temporary directory
+    os.chdir(tmp_path)
+    print(pathlib.Path.cwd())
+    print(project_id)
+
+    run(runner, ["--debug", "--profile", "local", "init", project_id, "--no-server"],
+        expected_files=[".g3t", ".git"])
+
+    # create test files
+    cmds = """
+    mkdir my-project-data
+    mkdir my-read-only-data
+    echo "hello" > my-project-data/hello.txt
+    echo "big-data" > my-read-only-data/big-file.txt
+    ln -s $PWD/my-read-only-data/big-file.txt my-project-data/big-file.txt
+    """.split('\n')
+    for cmd in cmds:
+        run_command(cmd, no_capture=True)
+
+    assert pathlib.Path("my-project-data/hello.txt").exists(), "hello.txt does not exist."
+    assert pathlib.Path("my-read-only-data/big-file.txt").exists(), "my-read-only-data/big-file.txt does not exist."
+    assert pathlib.Path("my-project-data/big-file.txt").exists(), "my-project-data/big-file.txt does not exist."
+
+    files = ["my-project-data/hello.txt", "my-project-data/big-file.txt"]
+    patients = ["P1", "P2"]
+    for f, p in zip(files, patients):
+        run(runner, ["--debug", "add", str(f), "--patient", p], expected_files=[f"MANIFEST/{f}.dvc"])
+
+    run(runner, ["--debug", "meta", "init"], expected_files=["META/DocumentReference.ndjson", "META/Patient.ndjson", "META/ResearchStudy.ndjson", "META/ResearchSubject.ndjson"])
+    run(runner, ["--debug", "meta", "validate"])
+    run(runner, ["commit", "-m",  "init", "MANIFEST/", "META/", ".g3t", ".gitignore"])
+
+    # now change the project_id to something new
+    # this should cause invalid object_id errors
+    config = gen3_tracker.config.default()
+    config.gen3.project_id = config.gen3.project_id + "XXXX"
+    with open('.g3t/config.yaml', 'w') as f:
+        yaml.dump(config.model_dump(), f)
+    run(runner, ["commit", "-m",  "change-project_id", '.g3t/config.yaml'])
+
+    # should error now
+    run(runner, ["--debug", "meta", "validate"], expected_exit_code=1)
+    run(runner, ["--debug", "push", "--dry-run"], expected_exit_code=1)
+    # also check skip_validate
+    run(runner, ["--debug", "push", "--dry-run", "--skip_validate"], expected_exit_code=0)
+
+    # should pass now
+    config.gen3.project_id = config.gen3.project_id.replace("XXXX", "")
+    with open('.g3t/config.yaml', 'w') as f:
+        yaml.dump(config.model_dump(), f)
+    run(runner, ["commit", "-m",  "restore-project_id", '.g3t/config.yaml'])
+
+    run(runner, ["--debug", "meta", "validate"], expected_exit_code=0)
+    run(runner, ["--debug", "push", "--dry-run"], expected_exit_code=0)
+
+
+def test_assert_add_specimen_after_init(runner: CliRunner, project_id, tmp_path: pathlib.Path) -> None:
+    """Test meta skeleton handles re-add of data with new specimen"""
+    # change to the temporary directory
+    os.chdir(tmp_path)
+    print(pathlib.Path.cwd())
+    print(project_id)
+
+    # init the project, no server
+    run(runner, ["--debug", "--profile", "local", "init", project_id, "--no-server"],
+        expected_files=[".g3t", ".git"])
+
+    # create test files
+    cmds = """
+    mkdir my-project-data
+    mkdir my-read-only-data
+    echo "hello" > my-project-data/hello.txt
+    echo "big-data" > my-read-only-data/big-file.txt
+    ln -s $PWD/my-read-only-data/big-file.txt my-project-data/big-file.txt
+    """.split('\n')
+    for cmd in cmds:
+        run_command(cmd, no_capture=True)
+
+    assert pathlib.Path("my-project-data/hello.txt").exists(), "hello.txt does not exist."
+    assert pathlib.Path("my-read-only-data/big-file.txt").exists(), "my-read-only-data/big-file.txt does not exist."
+    assert pathlib.Path("my-project-data/big-file.txt").exists(), "my-project-data/big-file.txt does not exist."
+
+    def _files_with_patients():
+        files = ["my-project-data/hello.txt", "my-project-data/big-file.txt"]
+        patients = ["P1", "P2"]
+        for f, p in zip(files, patients):
+            run(runner, ["--debug", "add", str(f), "--patient", p], expected_files=[f"MANIFEST/{f}.dvc"])
+
+        run(runner, ["--debug", "meta", "init"], expected_files=["META/DocumentReference.ndjson", "META/Patient.ndjson", "META/ResearchStudy.ndjson", "META/ResearchSubject.ndjson"])
+        run(runner, ["--debug", "meta", "validate"])
+        run(runner, ["commit", "-m",  "init", "MANIFEST/", "META/", ".g3t", ".gitignore"])
+
+    def _files_with_patients_and_specimens():
+        files = ["my-project-data/hello.txt", "my-project-data/big-file.txt"]
+        patients = ["P1", "P2"]
+        specimens = ["S1", "S2"]
+        for f, p, s in zip(files, patients, specimens):
+            run(runner, ["--debug", "add", str(f), "--patient", p, "--specimen", s], expected_files=[f"MANIFEST/{f}.dvc"])
+
+        run(runner, ["--debug", "meta", "init"], expected_files=["META/DocumentReference.ndjson", "META/Patient.ndjson", "META/ResearchStudy.ndjson", "META/ResearchSubject.ndjson", "META/Specimen.ndjson"])
+        run(runner, ["--debug", "meta", "validate"])
+        run(runner, ["commit", "-m", "init", "MANIFEST/", "META/", ".g3t", ".gitignore"])
+
+    # create initial association between patients and files
+    _files_with_patients()
+    # now add association between patients, specimens and files
+    _files_with_patients_and_specimens()
+    # should still pass
+    run(runner, ["--debug", "push", "--dry-run"], expected_exit_code=0)


### PR DESCRIPTION
This PR:
* Adds "validate object ids" within the validate cli command to detect project_id / object id changes.   `push` now runs validate by default, this can be skipped by adding using the new `--skip_validate` option
* Adds a test to ensure that `meta init` can be re-run an pick up new identifiers.  e.g.:
  * `g3t add xxx.txt --patient P1;  g3t commit ... ; g3t meta init`
  * `g3t add xxx.txt --patient P1 --specimen S1;  g3t commit ... ; g3t meta init` # <- META/Specimen.ndjson should exist