### PR TITLE
create .gitignore to only ignore top level logs directory

### DIFF
--- a/gen3_tracker/git/cli.py
+++ b/gen3_tracker/git/cli.py
@@ -540,10 +540,6 @@ def push(
                 config, metadata={"project_id": config.gen3.project_id}, auth=auth
             )["records"]
             dids = {_["did"]: _["updated_date"] for _ in records}
-            print("dvc_objects:", dvc_objects)
-            print("records:", len(records))
-            print("dids:", len(dids))
-            print("fa26f490-d9b0-537d-b1cd-8a261a26727f" in dids)
             new_dvc_objects = [_ for _ in dvc_objects if _.object_id not in dids]
             updated_dvc_objects = [
                 _

--- a/gen3_tracker/git/cli.py
+++ b/gen3_tracker/git/cli.py
@@ -207,7 +207,7 @@ def ensure_git_repo(config):
     pathlib.Path("META").mkdir(exist_ok=True)
     pathlib.Path("LOGS").mkdir(exist_ok=True)
     with open(".gitignore", "w") as f:
-        f.write("LOGS/\n")
+        f.write("/LOGS/\n")
         f.write(".g3t/state/\n")  # legacy
     with open("META/README.md", "w") as f:
         f.write(
@@ -528,6 +528,7 @@ def push(
             ), f"# There are {len(changes)} data files that you need to update.  See `g3t status`"
 
             # initialize dvc objects with this project_id
+            # dvc objects are retrieved only if committed to git
             committed_files, dvc_objects = manifest(config.gen3.project_id)
 
             # initialize gen3 client
@@ -539,6 +540,10 @@ def push(
                 config, metadata={"project_id": config.gen3.project_id}, auth=auth
             )["records"]
             dids = {_["did"]: _["updated_date"] for _ in records}
+            print("dvc_objects:", dvc_objects)
+            print("records:", len(records))
+            print("dids:", len(dids))
+            print("fa26f490-d9b0-537d-b1cd-8a261a26727f" in dids)
             new_dvc_objects = [_ for _ in dvc_objects if _.object_id not in dids]
             updated_dvc_objects = [
                 _

--- a/gen3_tracker/git/cloner.py
+++ b/gen3_tracker/git/cloner.py
@@ -2,7 +2,7 @@ import logging
 
 
 def ls(config, object_id: str = None, metadata: dict = {}, auth=None):
-    """List files."""
+    """List files stored in indexd on gen3."""
     from gen3_tracker import Config
     config: Config = config
     from gen3.index import Gen3Index


### PR DESCRIPTION
Fixes bug where a user is unable to `g3t add` a file with a path containing `logs/` due to our automatically created gitignore. See command and error below:

`
$g3t --debug add s3://gdcdata/164de210-a12c-4ed0-b6a3-484da8070a56/164de210-a12c-4ed0-b6a3-484da8070a56/logs/4320d40e-6ce1-4c13-a260-751281314aed_wgs_gdc_realn.bai.parcel --etag 4cf6696ff7ceaf288ca1d6a58ba96ea8 --size 751 --modified '2024-11-19T04:55:27-08:00`

> The following paths are ignored by one of your .gitignore files:
MANIFEST/gdcdata/164de210-a12c-4ed0-b6a3-484da8070a56/164de210-a12c-4ed0-b6a3-484da8070a56/logs
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"
Command 'git add MANIFEST/gdcdata/164de210-a12c-4ed0-b6a3-484da8070a56/164de210-a12c-4ed0-b6a3-484da8070a56/logs/4320d40e-6ce1-4c13-a260-751281314aed_wgs_gdc_realn.bai.parcel.dvc .gitignore' returned non-zero exit status 1.