### PR TITLE
fix identifier naming assumptions

### DIFF
--- a/gen3_tracker/collaborator/access/policies/add-project-default.yaml
+++ b/gen3_tracker/collaborator/access/policies/add-project-default.yaml
@@ -1,6 +1,10 @@
 policies:
 # submitter policy
 - role_ids:
+  - sower_user
+  resource_paths:
+  - /sower
+- role_ids:
   - writer
   resource_paths:
   - /programs/PROGRAM/projects/PROJECT

--- a/gen3_tracker/collaborator/access/policies/add-user-write.yaml
+++ b/gen3_tracker/collaborator/access/policies/add-user-write.yaml
@@ -7,6 +7,7 @@ policies:
 - policy_id: data_upload
   username:
 
-# gateway writer
-- policy_id: mds_gateway
+# sower
+- policy_id: sower
   username:
+

--- a/gen3_tracker/meta/dataframer.py
+++ b/gen3_tracker/meta/dataframer.py
@@ -681,7 +681,11 @@ def create_dataframe(
             "Dataframe is empty, are there any DocumentReference resources?"
         )
 
-    front_column_names = ["resourceType", "identifier"]
+    front_column_names = []
+    if "identifier" in df.columns:
+        front_column_names += ["identifier"]
+    if "resourceType" in df.columns:
+        front_column_names +=  ["resourceType"]
     if "patient" in df.columns:
         front_column_names = front_column_names + ["patient"]
 

--- a/gen3_tracker/meta/entities.py
+++ b/gen3_tracker/meta/entities.py
@@ -293,7 +293,7 @@ class SimplifiedFHIR(BaseModel):
             base_identifier = {
                 (
                     "identifier"
-                    if  i == 0 or identifier.get("use", "") == "official"
+                    if "-" in identifier.get("system", "").split("/")[-1] or i == 0
                     else identifier.get("system").split("/")[-1]
                 ): identifier.get("value")
                 for i, identifier in enumerate(identifiers)

--- a/gen3_tracker/meta/entities.py
+++ b/gen3_tracker/meta/entities.py
@@ -293,7 +293,7 @@ class SimplifiedFHIR(BaseModel):
             base_identifier = {
                 (
                     "identifier"
-                    if "-" in identifier.get("system", "").split("/")[-1] or i == 0
+                    if  i == 0 or identifier.get("use", "") == "official"
                     else identifier.get("system").split("/")[-1]
                 ): identifier.get("value")
                 for i, identifier in enumerate(identifiers)

--- a/gen3_tracker/meta/entities.py
+++ b/gen3_tracker/meta/entities.py
@@ -289,14 +289,14 @@ class SimplifiedFHIR(BaseModel):
         elif identifiers_len == 1:
             return {"identifier": identifiers[0].get("value")}
         else:
-            # Todo: Raise an execption if there are multiple identifiers with a "-" in them
+            # assume that 0th identifier is the base identifier
             base_identifier = {
                 (
                     "identifier"
-                    if "-" in identifier.get("system", "").split("/")[-1]
+                    if "-" in identifier.get("system", "").split("/")[-1] or i == 0
                     else identifier.get("system").split("/")[-1]
                 ): identifier.get("value")
-                for identifier in identifiers
+                for i, identifier in enumerate(identifiers)
             }
 
             return base_identifier

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name='gen3_tracker',
-    version='0.0.7rc12',
+    version='0.0.7rc13',
     description='A CLI for adding version control to Gen3 data submission projects.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -48,11 +48,11 @@ def validate_document_in_grip(did: str, auth=None, project_id=None):
         auth = ensure_auth(config=default())
     token = auth.get_access_token()
     result = requests.get(
-        f"{auth.endpoint}/grip/writer/graphql/CALIPER/get-vertex/{did}/{project_id}",
+        f"{auth.endpoint}/grip/writer/CALIPER/get-vertex/{did}/{project_id}",
         headers={"Authorization": f"bearer {token}"},
     ).json()
     assert "data" in result, f"Failed to query grip for {did} {result}"
-    assert result["data"]["gid"] == did
+    assert result["data"]["id"] == did
 
 
 def validate_document_in_elastic(did, auth):


### PR DESCRIPTION
HTAN data was not passing the dataframer because Docref identifiers didn't contain a '-' so there wasn't an "identifier" that was getting rendered out at the end so it was breaking. 

This adds the 'or' statement to assume that the first identifier listed is the base identifier