### PR TITLE
`development` ← `fix/github-actions`: Cleaning up GitHub Actions workflows :shipit: 

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -22,7 +22,7 @@ on:
 
     inputs:
       environment:
-        description: The target environment for this run (e.g. development, staging, production, cbds)
+        description: The target environment for this run (e.g. external, internal)
         required: true
         type: string
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,39 +5,10 @@ on:
   workflow_dispatch: # Allow manual triggering of the workflow
 
 jobs:
-  cbds:
+  external:
     with:
-        environment: cbds
-        endpoint: "https://idp.cbds.ohsu.edu"
-        # Self-hosted runner to access https://idp.cbds.ohsu.edu
-        # https://github.com/ACED-IDP/gen3_util/settings/actions/runners/21
-        # https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners#adding-a-self-hosted-runner-to-a-repository
-        runs-on: self-hosted
-        program: cbds
-    secrets:
-        CREDENTIALS: ${{ secrets.CREDENTIALS }}
-    uses: ./.github/workflows/integration.yaml
-    
-  production:
-    with:
-      environment: production
+      environment: external
       endpoint: "https://aced-idp.org"
-    secrets:
-      CREDENTIALS: ${{ secrets.CREDENTIALS }}
-    uses: ./.github/workflows/integration.yaml
-
-  staging:
-    with:
-      environment: staging
-      endpoint: "https://staging.aced-idp.org"
-    secrets:
-      CREDENTIALS: ${{ secrets.CREDENTIALS }}
-    uses: ./.github/workflows/integration.yaml
-
-  development:
-    with:
-      environment: development
-      endpoint: "https://development.aced-idp.org"
     secrets:
       CREDENTIALS: ${{ secrets.CREDENTIALS }}
     uses: ./.github/workflows/integration.yaml

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -17,11 +17,8 @@ on:
 
 jobs:
   pytest:
-    # We're testing 'cbds' by default so we can use the self-hosted runner to access htps://idp.cbds.ohsu.edu
-    # https://github.com/ACED-IDP/gen3_util/settings/actions/runners/21
-    # https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners#adding-a-self-hosted-runner-to-a-repository
-    environment: cbds
-    runs-on: self-hosted
+    environment: external
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -54,8 +54,8 @@ jobs:
           echo $CREDENTIALS > ~/.gen3/credentials.json
 
           # Hardcoding the endpoint for now
-          # TODO: Should we make this configurable to run `pytest` against all Gen3 instances?
-          export ENDPOINT="https://idp.cbds.ohsu.edu"
+          # TODO: Can we make this configurable to run `pytest` against all Gen3 instances?
+          export ENDPOINT="https://aced-idp.org"
 
           gen3-client configure --profile=CALIPER --cred=~/.gen3/credentials.json --apiendpoint="$ENDPOINT"
           export G3T_PROFILE=CALIPER


### PR DESCRIPTION
> [!WARNING]
> Work in Progress — currently resolving test failures below ⚠️  

# Overview 🌀 

Cleaning up deprecated environments (e.g. [`development`](https://github.com/ACED-IDP/gen3_util/actions/runs/14502148999#summary-40684092983)/[`staging`](https://github.com/ACED-IDP/gen3_util/actions/runs/14502148999#summary-40684092979)) and resolving minor [Pytest errors](https://github.com/ACED-IDP/gen3_util/actions/runs/14604357400/job/40969876567) blocking successful GitHub Actions workflows

## Current Behavior ❌ 

Current Actions are failing on deprecated environments (e.g. [`development`](https://github.com/ACED-IDP/gen3_util/actions/runs/14502148999#summary-40684092983)/[`staging`](https://github.com/ACED-IDP/gen3_util/actions/runs/14502148999#summary-40684092979)) as well as [Pytest failures](https://github.com/ACED-IDP/gen3_util/actions/runs/14604357400/job/40969876567)

## New Behavior ✅ 

All actions succeed for:
1.  The external CALIPER environment at https://aced-idp.org ([integration.yaml](.github/workflows/integration.yaml))
2. All Pytest tests ([pytest.yaml](./.github/workflows/pytest.yaml)
