### PR TITLE
feature/multi-hash

### DIFF
--- a/gen3_tracker/gen3/indexd.py
+++ b/gen3_tracker/gen3/indexd.py
@@ -6,6 +6,7 @@ import requests
 from gen3.auth import Gen3Auth
 from gen3.index import Gen3Index
 
+from gen3_tracker.common import ACCEPTABLE_HASHES
 from gen3_tracker.git import DVC, DVCMeta
 
 
@@ -89,7 +90,7 @@ def create_hashes_metadata(dvc: DVC, program, project):
     if not meta:
         meta = DVCMeta()
 
-    hashes = {dvc.out.hash: getattr(dvc.out, dvc.out.hash)}
+    hashes = {h: getattr(dvc.out, h) for h in ACCEPTABLE_HASHES if hasattr(dvc.out, h) and getattr(dvc.out, h)}
     metadata = {
         **{
             'document_reference_id': dvc.object_id,

--- a/gen3_tracker/git/cli.py
+++ b/gen3_tracker/git/cli.py
@@ -542,9 +542,15 @@ def push(
             bucket_name = get_program_bucket(config=config, auth=auth)
 
             # check for new files
-            records = ls(
-                config, metadata={"project_id": config.gen3.project_id}, auth=auth
-            )["records"]
+            if dry_run:
+                click.secho(
+                    "Dry run: not indexing files", fg=INFO_COLOR, file=sys.stderr
+                )
+                records = []
+            else:
+                records = ls(
+                    config, metadata={"project_id": config.gen3.project_id}, auth=auth
+                )["records"]
             dids = {_["did"]: _["updated_date"] for _ in records}
             new_dvc_objects = [_ for _ in dvc_objects if _.object_id not in dids]
             updated_dvc_objects = [

--- a/gen3_tracker/meta/cli.py
+++ b/gen3_tracker/meta/cli.py
@@ -49,14 +49,16 @@ def init(ctx, project_id, debug, bundle):
 
 @meta.command()
 @click.argument('directory', type=click.Path(exists=True), default='META')
-@click.option('--debug', is_flag=True)
+@click.option('--debug', is_flag=True, default=False, show_default=True, help='Enable debug mode.')
+@click.option('--skip-id-check', is_flag=True, default=False, show_default=True, help='Skip checking that resource IDs are valid for the project.')
 @click.pass_obj
-def validate(ctx, directory, debug):
+def validate(ctx, directory, debug, skip_id_check):
     """Validate FHIR data"""
     try:
         from gen3_tracker.meta.validator import validate as validate_dir
         with Halo(text='Validating', spinner='line', placement='right', color='white'):
-            result = validate_dir(directory, project_id=ctx.gen3.project_id)
+            project_id = ctx.gen3.project_id if not skip_id_check else None
+            result = validate_dir(directory, project_id=project_id)
         click.secho(result.resources, fg=INFO_COLOR, file=sys.stderr)
         for _ in result.exceptions:
             click.secho(f"{_.path}:{_.offset} {_.exception}", fg=ERROR_COLOR, file=sys.stderr)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name='gen3_tracker',
-    version='0.0.7rc15',
+    version='0.0.7rc17',
     description='A CLI for adding version control to Gen3 data submission projects.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/unit/meta/test_meta.py
+++ b/tests/unit/meta/test_meta.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import sys
 
 import yaml
 from click.testing import CliRunner
@@ -82,6 +83,8 @@ def test_assert_object_id_invalid_on_project_id_change(
     run(runner, ["--debug", "meta", "validate"], expected_exit_code=1)
     run(runner, ["--debug", "push", "--dry-run"], expected_exit_code=1)
     # also check skip_validate
+    print(">>>> Running push with --skip_validate")
+    print(">>>> Running push with --skip_validate", file=sys.stderr)
     run(
         runner,
         ["--debug", "push", "--dry-run", "--skip_validate"],

--- a/tests/unit/test_hash_types.py
+++ b/tests/unit/test_hash_types.py
@@ -3,6 +3,9 @@ from pydantic import ValidationError
 
 from gen3_tracker.common import ACCEPTABLE_HASHES
 from gen3_tracker.git import DVCItem
+from gen3_tracker.gen3.indexd import create_hashes_metadata
+from gen3_tracker.common import ACCEPTABLE_HASHES
+
 
 VALID_HASHES = {
     "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
@@ -33,3 +36,58 @@ def test_valid_hash_values():
         print(_)
         item = DVCItem(**_)
         print(item)
+
+
+class DummyOut:
+    """
+    Dummy class to simulate an object with hash attributes.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """
+        Initialize DummyOut with arbitrary attributes.
+        """
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class DummyDVC:
+    """
+    Dummy class to simulate a DVC object with object_id, out, and meta.
+    """
+
+    def __init__(self, object_id: str, out: DummyOut, meta: "DummyMeta") -> None:
+        """
+        Initialize DummyDVC with object_id, out, and meta.
+        """
+        self.object_id = object_id
+        self.out = out
+        self.meta = meta
+
+
+class DummyMeta:
+    """
+    Dummy class to simulate metadata for DVC objects.
+    """
+
+    specimen: str = "spec1"
+    patient: str = "pat1"
+    task: str = "task1"
+    observation: str = "obs1"
+    no_bucket: bool = False
+
+
+def test_create_hashes_metadata_fills_hashes() -> None:
+    """
+    Test that create_hashes_metadata fills the hashes dict with all present and non-empty attributes
+    from ACCEPTABLE_HASHES on dvc.out.
+    """
+    out = DummyOut(md5="abc", sha256="def", sha1=None)
+    dvc = DummyDVC(object_id="guid1", out=out, meta=DummyMeta())
+    hashes, metadata = create_hashes_metadata(dvc, "prog", "proj")
+    for h in ACCEPTABLE_HASHES:
+        if hasattr(out, h) and getattr(out, h):
+            assert h in hashes
+            assert hashes[h] == getattr(out, h)
+        else:
+            assert h not in hashes

--- a/tests/unit/test_hash_types.py
+++ b/tests/unit/test_hash_types.py
@@ -1,7 +1,6 @@
 import pytest
 from pydantic import ValidationError
 
-from gen3_tracker.common import ACCEPTABLE_HASHES
 from gen3_tracker.git import DVCItem
 from gen3_tracker.gen3.indexd import create_hashes_metadata
 from gen3_tracker.common import ACCEPTABLE_HASHES


### PR DESCRIPTION
This PR:
* ensures all hashes in dvc file are sent to indexd
* adds a -skip-id-check to `meta init`
* for `push -dry-run` - don't call indexd.get (indexd get permissions)
