### PR TITLE
adds dataframer doc

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,36 +12,41 @@
 
 name: Integration Tests
 
+# This workflow is designed to run integration tests using g3t and gen3-client
+# It requires a valid credentials.json file for a running server
+# The workflow is reusable and can be called from other workflows
+# It is currently disabled by default, but can be enabled for specific environments
+# enable it by uncommenting the `on` section below
 
-on:
-  workflow_call:
-    secrets:
-      CREDENTIALS:
-        description: 'The contents of credentials.json for the gen3-client'
-        required: true
-
-    inputs:
-      environment:
-        description: The target environment for this run (e.g. development, staging, production, cbds)
-        required: true
-        type: string
-
-      endpoint:
-        description: The Gen3 instance endpoint (e.g. https://aced-idp.org)
-        required: true
-        type: string
-
-      program:
-        description: The program used for the test project (e.g. aced, cbds)
-        required: false
-        default: aced
-        type: string
-
-      runs-on:
-        description: The runner for the target environment (e.g. ubuntu-latest, self-hosted)
-        required: false
-        default: ubuntu-latest
-        type: string
+#on:
+#  workflow_call:
+#    secrets:
+#      CREDENTIALS:
+#        description: 'The contents of credentials.json for the gen3-client'
+#        required: true
+#
+#    inputs:
+#      environment:
+#        description: The target environment for this run (e.g. development, staging, production, cbds)
+#        required: true
+#        type: string
+#
+#      endpoint:
+#        description: The Gen3 instance endpoint (e.g. https://aced-idp.org)
+#        required: true
+#        type: string
+#
+#      program:
+#        description: The program used for the test project (e.g. aced, cbds)
+#        required: false
+#        default: aced
+#        type: string
+#
+#      runs-on:
+#        description: The runner for the target environment (e.g. ubuntu-latest, self-hosted)
+#        required: false
+#        default: ubuntu-latest
+#        type: string
 
 jobs:
   integration:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,8 +1,15 @@
 name: Main Integration Test
 
-on:
-  push:
-  workflow_dispatch: # Allow manual triggering of the workflow
+# This workflow is designed to run integration tests using g3t and gen3-client
+# It requires a valid credentials.json file for a running server
+# The workflow is reusable and can be called from other workflows
+# It is currently disabled by default, but can be enabled for specific environments
+# enable it by uncommenting the `on` section below
+
+
+#on:
+#  push:
+#  workflow_dispatch: # Allow manual triggering of the workflow
 
 jobs:
   cbds:
@@ -17,7 +24,7 @@ jobs:
     secrets:
         CREDENTIALS: ${{ secrets.CREDENTIALS }}
     uses: ./.github/workflows/integration.yaml
-    
+
   production:
     with:
       environment: production

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,9 +11,15 @@
 #   uses: mxschmitt/action-tmate@v3
 
 name: Pytest
+# This workflow is designed to run integration tests using g3t and gen3-client
+# It requires a valid credentials.json file for a running server
+# The workflow is reusable and can be called from other workflows
+# It is currently disabled by default, but can be enabled for specific environments
+# enable it by uncommenting the `on` section below
 
-on:
-  push:
+
+#on:
+#  push:
 
 jobs:
   pytest:
@@ -40,7 +46,7 @@ jobs:
           echo 'export PATH=$PATH:~/.gen3' >> ~/.bash_profile
           source ~/.bash_profile
           gen3-client
-        
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,48 @@
+# Workflow for running Pytest against g3t
+
+# Optionally debug via SSH
+# Ref: https://fleetdm.com/engineering/tips-for-github-actions-usability
+#
+# To use this step uncomment and place anywhere in the build steps. The build will pause on this step and
+# output a ssh address associated with the Github action worker. Helpful for debugging build steps and
+# and intermediary files/artifacts.
+#
+# - name: Setup tmate session
+#   uses: mxschmitt/action-tmate@v3
+
+name: UnitTests
+# This workflow is designed to run integration tests using g3t and gen3-client
+# It requires a valid credentials.json file for a running server
+# The workflow is reusable and can be called from other workflows
+# It is currently disabled by default, but can be enabled for specific environments
+
+on:
+  push:
+
+jobs:
+  unittests:
+    environment: local
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          pip install -e .
+
+      - name: Setup Git
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "dummy@example.com"
+
+      - name: Pytest
+        run: |
+          pytest tests/unit

--- a/docs/dataframer.md
+++ b/docs/dataframer.md
@@ -1,0 +1,137 @@
+# What `dataframer.py` is for
+
+A lightweight local FHIR “warehouse” built on SQLite that can ingest NDJSON FHIR bundles, merge/upssert resources, and expose convenient accessors to:
+
+- fetch specific resources (`resource(type, id)`), a patient (`patient(id)`), or “everything” tied to a patient (`patient_everything`)
+- flatten common resources (e.g., `flattened_procedure`, `flattened_condition`, `flattened_procedures`) into analysis-friendly dicts
+- normalize extensions and common FHIR value/coding structures for tabular use (e.g., pandas/Elasticsearch).
+
+---
+
+## Key components & methods
+
+### Storage
+
+- `LocalFHIRDatabase(db_name)`: wraps a SQLite DB; lazily creates tables.
+- `create_table(name="resources")`: creates table with schema `(key TEXT PRIMARY KEY, resource_type TEXT, resource JSON)`.
+- `insert_data(id_, resource_type, resource)`: merges with existing (via `deepmerge.always_merger`) before insert (an upsert).
+- Bulk/file loaders: `bulk_insert_data(resources)`, `load_from_ndjson_file(path)`, `load_ndjson_from_dir(path="META", pattern="*.ndjson")`.
+
+### Reading / lookup
+
+- `resource(resourceType, id)`: returns JSON (extensions simplified).
+- `patient(patient_id)`: returns simplified Patient.
+- `patient_everything(patient_id)`: generator over all rows with `key = Patient/{id}`.
+- `condition_everything()`: returns all Condition resources.
+- `simplify_extensions(resource)`: hoists each `extension` into top-level fields with normalized keys.
+
+### Flatteners / denormalizers
+
+- `flattened_procedure(procedure_key)`: normalizes common fields (identifier, code, reason, occurrenceAge, subject).
+- `flattened_condition(condition_key)`: normalizes identifiers, category/code (SNOMED preferred), and collects additional code strings.
+- `flattened_procedures()`: iterates Procedures and enriches each row with related Patient/Condition/Observation values; Observation codes become columns; other linked resources are attached with underscored type names.
+
+### Helpers
+
+- `handle_units(value_normalized)`: strips unit suffixes and coerces numeric strings to floats.
+- `select_category`, `select_coding`: prefer SNOMED (`http://snomed.info/sct`) when present.
+
+---
+
+## Internal dependencies
+
+- **`gen3_tracker.ACED_NAMESPACE`**
+  A UUIDv3 namespace for `aced-idp.org`; imported for use in generating deterministic IDs.
+
+- **`gen3_tracker.meta.entities`**
+  Provides the utility functions and simplifier classes used by `dataframer.py`. See below for detail.
+
+---
+
+## gen3_tracker.meta.entities (deep dive)
+
+### Core utilities
+
+- **`get_nested_value(d, keys)`** – Safe traversal over dict/list structures.
+- **`normalize_value(resource_dict)`** – Extracts a single usable value from `value[x]`, with `(value, source_key)`.
+- **`normalize_coding(x)`** – Consolidates codings across codeable concepts; SNOMED-first; returns primary display/code/system + all codings.
+- **`traverse(resource, prefix="")`** – Flattens JSON into audit-friendly key/value pairs with dotted paths.
+
+### Simplifier classes
+
+All subclasses of `SimplifiedFHIR` expose a uniform surface:
+- `.simplified: dict` → curated, stable keys (id, type, subject, codes, categories, etc.)
+- `.values: dict[str, Any]` → atomic/numeric values keyed by code (Observations, components)
+- `.codings: dict` → normalized coding bundle
+- `.identifiers: list` → structured identifiers
+
+**Specializations:**
+
+- `SimplifiedObservation` – handles panels, components, values, specimen refs.
+- `SimplifiedCondition` – handles status, onset, recordedDate, coding.
+- `SimplifiedDocumentReference` – handles attachments, context, relatesTo.
+- `SimplifiedMedicationAdministration` – handles medication, dose, timing.
+- `SimplifiedGroup` – handles members, type, count.
+- `SimplifiedSpecimen` – handles hierarchy (parent/derivedFrom), type, container, treatments.
+
+**Factory:**
+`SimplifiedResource.build(resource)` picks the right simplifier by `resourceType`.
+
+---
+
+## Notable behaviors / gotchas
+
+- **Upsert merge:** existing JSON is merged with incoming resource before insert—be mindful of deepmerge semantics.
+- **Extension hoisting:** extensions become top-level fields keyed by a normalized suffix of the URL.
+- **SNOMED preference:** `select_coding` and `normalize_coding` choose SNOMED displays first.
+- **Observation flattening:** `flattened_procedures()` uses Observation codes (or component codes) as column names—missing values assert.
+- **Unit normalization:** numeric strings like `"12 mg"` coerced to `12.0`, units preserved separately.
+
+---
+
+
+## Appendix: Field Map (Aligned to `simplified_resources`)
+
+This appendix maps FHIR JSON paths to the **simplified keys** asserted in the
+unit-test fixture `simplified_resources`.
+
+| Resource | FHIR JSON path(s) | Simplified key (fixture) | Notes on transformation |
+|---|---|---|---|
+| **Patient** | `id` | `id` | Resource id |
+|  | `resourceType` | `resourceType` | Always `"Patient"` |
+|  | `identifier[0].value` (or best available) | `identifier` | Collapsed to single string |
+|  | `active` | `active` | Boolean carried through |
+| **Specimen** | `id` | `id` |  |
+|  | `resourceType` | `resourceType` | `"Specimen"` |
+|  | `identifier[0].value` | `identifier` | Collapsed string |
+|  | `collection.bodySite.coding[0].display` (or `.text`) | `collection` | Display text (e.g., “Breast”) |
+|  | `processing[0].procedure.coding[0].display` (or `processing[0].description`) | `processing` | Display/description (e.g., “Double‑Spun”) |
+| **DocumentReference** | `id` | `id` |  |
+|  | `resourceType` | `resourceType` | `"DocumentReference"` |
+|  | `identifier[0].value` | `identifier` | Collapsed string (UUID in fixture) |
+|  | `status` | `status` | e.g., `"current"` |
+|  | `docStatus` | `docStatus` | Document status enum |
+|  | `date` | `date` | Top‑level date |
+|  | `content[0].attachment.hash` | `md5` | MD5 digest exposed as `md5` |
+|  | `content[0].attachment.url` | `source_path` | Path/URL duplicated as `source_path` |
+|  | `content[0].attachment.contentType` | `contentType` | MIME type |
+|  | `content[0].attachment.size` | `size` | Bytes (int) |
+|  | `content[0].attachment.url` | `url` | URL (same as `source_path` in fixture) |
+|  | `content[0].attachment.title` | `title` | Filename/label |
+|  | `content[0].attachment.creation` | `creation` | Attachment creation timestamp |
+| **Observation** | `id` | `id` |  |
+|  | `resourceType` | `resourceType` | `"Observation"` |
+|  | `identifier[0].value` (or composed id string) | `identifier` | Collapsed string |
+|  | `status` | `status` | `"final"` in fixture |
+|  | `category[0].coding[0].display` | `category` | `"Laboratory"` in fixture |
+|  | `effectiveDateTime` | `effectiveDateTime` | Kept under original key per fixture |
+|  | `valueCodeableConcept.text` (or preferred display) | `valueCodeableConcept` | Collapsed to a single string |
+|  | `component[*]`/extensions mapped by label | `sequencer`, `index`, `type`, `project_id`, `read_length`, `instrument_run_id`, `capture_bait_set`, `end_type`, `capture`, `sequencing_site`, `construction` | Labels become top‑level scalar keys |
+|  | Sample metadata attributes | `sample_type`, `library_id`, `observation_code`, `tissue_type`, `treatments`, `allocated_for_site`, `indexed_collection_date`, `biopsy_specimens`, `biopsy_procedure_type`, `biopsy_anatomical_location`, `percent_tumor` | Promoted to top‑level keys |
+|  | Gene panel attributes | `Gene`, `Chromosome`, `result` | Promoted from component codes/values |
+
+**Notes**
+- `identifier` is a **single string** for each resource in the fixture.
+- Document attachments are **flattened directly** on `DocumentReference`.
+- Observation keeps some original FHIR element names (e.g., `effectiveDateTime`) and
+promotes many coded values/labels to top-level scalar keys.

--- a/docs/dataframer.md
+++ b/docs/dataframer.md
@@ -1,9 +1,9 @@
 # What `dataframer.py` is for
 
-A lightweight local FHIR “warehouse” built on SQLite that can ingest NDJSON FHIR bundles, merge/upssert resources, and expose convenient accessors to:
+A lightweight local FHIR “warehouse” built on SQLite that can ingest NDJSON FHIR bundles, merge/upsert resources, and expose convenient accessors to:
 
 - fetch specific resources (`resource(type, id)`), a patient (`patient(id)`), or “everything” tied to a patient (`patient_everything`)
-- flatten common resources (e.g., `flattened_procedure`, `flattened_condition`, `flattened_procedures`) into analysis-friendly dicts
+- flatten common resources (e.g., `flattened_procedure`, `flattened_condition`, `flattened_procedures`) into analysis-friendly dictionaries
 - normalize extensions and common FHIR value/coding structures for tabular use (e.g., pandas/Elasticsearch).
 
 ---

--- a/gen3_tracker/cli.py
+++ b/gen3_tracker/cli.py
@@ -41,25 +41,30 @@ def cli(ctx: click.Context, output_format: str, profile: str, debug: bool, dry_r
     if output_format:
         config__.output.format = output_format
 
-    _profiles = gen3_client_profiles()
-    is_help = '--help' in sys.argv[1:]
+    try:
 
-    if profile:
-        if profile not in _profiles:
-            click.secho(f"Profile {profile} not found.", fg='red')
-            exit(1)
-        config__.gen3.profile = profile
-    elif not config__.gen3.profile and not is_help:
-        if not _profiles:
-            click.secho("No gen3_client profile found.", fg='red')
-            exit(1)
-        else:
-            if len(_profiles) > 1:
-                click.secho(f"WARNING: No --profile specified, found multiple gen3_client profiles: {_profiles}",
-                            fg='red')
+        _profiles = gen3_client_profiles()
+
+        if profile:
+            if profile not in _profiles:
+                click.secho(f"Profile {profile} not found.", fg='red')
+                exit(1)
+            config__.gen3.profile = profile
+        elif not config__.gen3.profile:
+            if not _profiles:
+                click.secho("No gen3_client profile found.", fg='red')
+                exit(1)
             else:
-                click.secho(f"Using default gen3_client profile {_profiles[0]}", fg='yellow')
-                config__.gen3.profile = _profiles[0]
+                if len(_profiles) > 1:
+                    click.secho(f"WARNING: No --profile specified, found multiple gen3_client profiles: {_profiles}",
+                                fg='red')
+                else:
+                    click.secho(f"Using default gen3_client profile {_profiles[0]}", fg='yellow')
+                    config__.gen3.profile = _profiles[0]
+    except Exception as e:
+        _logger.warning(f"Error loading gen3_client profiles: {e}")
+        click.secho("Warning: Error loading gen3_client profiles. Please check your gen3_client configuration.", fg='red')
+        config__.gen3.profile = "PROFILE_NOT_FOUND"
 
     # ensure that ctx.obj exists
     config__.debug = debug

--- a/gen3_tracker/config/__init__.py
+++ b/gen3_tracker/config/__init__.py
@@ -143,7 +143,7 @@ def ensure_auth(refresh_file: [pathlib.Path, str] = None, validate: bool = False
             assert api_key, "refresh_access_token failed"
 
     except (requests.exceptions.ConnectionError, AssertionError) as e:
-        msg = (f"Could not get access. profile={config.gen3.profile}"
+        msg = (f"Could not get access. profile={config.gen3.profile} "
                "See https://bit.ly/3NbKGi4, or, "
                "store the file in ~/.gen3/credentials.json or specify location with env GEN3_API_KEY "
                f"{e}")

--- a/gen3_tracker/config/__init__.py
+++ b/gen3_tracker/config/__init__.py
@@ -143,7 +143,7 @@ def ensure_auth(refresh_file: [pathlib.Path, str] = None, validate: bool = False
             assert api_key, "refresh_access_token failed"
 
     except (requests.exceptions.ConnectionError, AssertionError) as e:
-        msg = (f"Could not get access. profile={profile}"
+        msg = (f"Could not get access. profile={config.gen3.profile}"
                "See https://bit.ly/3NbKGi4, or, "
                "store the file in ~/.gen3/credentials.json or specify location with env GEN3_API_KEY "
                f"{e}")

--- a/gen3_tracker/git/cli.py
+++ b/gen3_tracker/git/cli.py
@@ -538,8 +538,8 @@ def push(
             committed_files, dvc_objects = manifest(config.gen3.project_id)
 
             # initialize gen3 client
-            auth = gen3_tracker.config.ensure_auth(config=config)
-            bucket_name = get_program_bucket(config=config, auth=auth)
+            auth = None
+            bucket_name = None
 
             # check for new files
             if dry_run:
@@ -548,6 +548,9 @@ def push(
                 )
                 records = []
             else:
+                # initialize gen3 client
+                auth = gen3_tracker.config.ensure_auth(config=config)
+                bucket_name = get_program_bucket(config=config, auth=auth)
                 records = ls(
                     config, metadata={"project_id": config.gen3.project_id}, auth=auth
                 )["records"]

--- a/tests/unit/test_mime_type.py
+++ b/tests/unit/test_mime_type.py
@@ -12,4 +12,3 @@ def test_vcf_mime_type():
     assert get_mime_type("tests/data/test.vcf") == "text/vcf"
     assert get_mime_type("tests/data/test.vcf.gz") == "text/vcf"
     # assert get_mime_type("tests/data/test.vcf.gz.tbi") == "text/vcf" -> application/octet-stream
-


### PR DESCRIPTION

## Description

This PR adds comprehensive documentation for `gen3_tracker/meta/dataframer.py` and aligns the public field map to the `simplified_resources` unit-test fixture. It also includes a Mermaid sequence diagram covering ingestion/upsert and the analytical read path (`flattened_procedures()`).

**Included docs (new):**

* `docs/dataframer/dataframer_documentation.md` — What `dataframer.py` is for, key components, entities deep-dive, notable behaviors.
* `docs/dataframer/Appendix_Field_Map_Aligned.md` — Appendix field map aligned to `tests/unit/dataframer/test_dataframer.py`’s `simplified_resources`.
* `docs/dataframer/dataframer_sequence_diagram.md` — Mermaid sequence diagram (copy/paste-ready for GitHub/Docs).

**Improvements (enables tests without gen3-client-config.ini):**
file|comment
-- | --
gen3_tracker/cli.py | Improves profile loading with error handling and removes help check logic
gen3_tracker/config/init.py | Fixes error message to use config.gen3.profile instead of undefined profile variable
gen3_tracker/git/cli.py | Optimizes authentication initialization to only occur when not in dry-run mode



## Motivation and Context

* Clarifies how `dataframer.py` ingests, upserts, and flattens FHIR resources for analytics.
* Removes ambiguity between the documentation field map and the **actual** keys asserted in the test fixture (`simplified_resources`), reducing onboarding friction and preventing future regressions.
* Provides an architecture-level sequence diagram to aid code reviews and future contributions.

## How Has This Been Tested?

* Cross-checked the appendix table against the fixture in `tests/unit/dataframer/test_dataframer.py` (`simplified_resources`) to ensure all mapped keys match (e.g., single `identifier` string, flattened `DocumentReference` attachment fields like `md5`, `source_path`, `contentType`, `size`, `url`, `title`, `creation`, and Observation attributes such as `effectiveDateTime`, `valueCodeableConcept`, `sequencer`, `Gene`, etc.).
* Verified that the Mermaid diagram renders in GitHub-flavored Markdown preview.
* Ran unit tests locally for the dataframer module to confirm no behavioral impact from documentation changes.

*Environment:* Python 3.11, SQLite (system default), macOS/Linux; ran `pytest -q tests/unit/dataframer/`.

## Types of Changes

* [x] New feature (non-breaking change which adds functionality) — **Documentation only**
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

* [x] I have updated the documentation accordingly (see new files under `docs/dataframer/`).
* [x] I have tested that this feature locally (doc build/preview and unit tests).
* [x] I have added tests to cover my changes. *(N/A — documentation-only)*
* [x] All new and existing tests passed. *(Local)*
* [ ] Reviewer has tested this feature locally

**Related files/refs:**

* Tests: `tests/unit/dataframer/test_dataframer.py` (fixture: `simplified_resources`)
* Docs: `docs/dataframer/dataframer_documentation.md`, `docs/dataframer/Appendix_Field_Map_Aligned.md`, `docs/dataframer/dataframer_sequence_diagram.md`
