### PR TITLE
Bugfix/secondary identifiers

### DIFF
--- a/gen3_tracker/meta/__init__.py
+++ b/gen3_tracker/meta/__init__.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, ConfigDict
 
 from gen3_tracker.common import is_json_extension, read_json, read_ndjson_file
 
-FHIR_CLASSES = importlib.import_module('fhir.resources')
+FHIR_CLASSES = importlib.import_module("fhir.resources")
 
 logger = logging.getLogger(__name__)
 
@@ -40,21 +40,27 @@ class ParseResult(BaseModel):
             return val
         if issubclass(type(val), FHIRAbstractModel):
             return val
-        raise TypeError(f"Wrong type for 'resource', was {type(val)} must be subclass of FHIRAbstractModel")
+        raise TypeError(
+            f"Wrong type for 'resource', was {type(val)} must be subclass of FHIRAbstractModel"
+        )
 
 
 def parse_obj(resource: dict, validate=True) -> ParseResult:
-    """Load a dictionary into a FHIR model """
+    """Load a dictionary into a FHIR model"""
     try:
-        assert 'resourceType' in resource, "Dict missing `resourceType`, is it a FHIR dict?"
-        klass = FHIR_CLASSES.get_fhir_model_class(resource['resourceType'])
+        assert (
+            "resourceType" in resource
+        ), "Dict missing `resourceType`, is it a FHIR dict?"
+        klass = FHIR_CLASSES.get_fhir_model_class(resource["resourceType"])
         _ = klass.parse_obj(resource)
         if validate:
             # trigger object traversal, see monkey patch below, at bottom of file
             _.dict()
         return ParseResult(resource=_, exception=None, path=None, resource_id=_.id)
     except (ValidationError, AssertionError) as e:
-        return ParseResult(resource=None, exception=e, path=None, resource_id=resource.get('id', None))
+        return ParseResult(
+            resource=None, exception=e, path=None, resource_id=resource.get("id", None)
+        )
 
 
 def _entry_iterator(parse_result: ParseResult) -> Iterator[ParseResult]:
@@ -68,12 +74,30 @@ def _entry_iterator(parse_result: ParseResult) -> Iterator[ParseResult]:
             for _ in parse_result.resource.entry:
                 if _ is None:
                     break
-                if hasattr(_, 'resource') and _.resource:  # BundleEntry
-                    yield ParseResult(path=_path, resource=_.resource, offset=offset, exception=None, json_obj=_.resource.dict())
-                elif hasattr(_, 'item'):  # ListEntry
-                    yield ParseResult(path=_path, resource=_.item, offset=offset, exception=None, json_obj=_.item.dict())
+                if hasattr(_, "resource") and _.resource:  # BundleEntry
+                    yield ParseResult(
+                        path=_path,
+                        resource=_.resource,
+                        offset=offset,
+                        exception=None,
+                        json_obj=_.resource.dict(),
+                    )
+                elif hasattr(_, "item"):  # ListEntry
+                    yield ParseResult(
+                        path=_path,
+                        resource=_.item,
+                        offset=offset,
+                        exception=None,
+                        json_obj=_.item.dict(),
+                    )
                 else:
-                    yield ParseResult(path=_path, resource=_.item, offset=offset, exception=None, json_obj=_.item.dict())
+                    yield ParseResult(
+                        path=_path,
+                        resource=_.item,
+                        offset=offset,
+                        exception=None,
+                        json_obj=_.item.dict(),
+                    )
                 offset += 1
     pass
 
@@ -85,9 +109,9 @@ def _has_entries(_: ParseResult):
     return _.resource.resource_type in ["List"] and _.resource.entry is not None
 
 
-def directory_reader(directory_path: str,
-                     recurse: bool = True,
-                     validate: bool = False) -> Iterator[ParseResult]:
+def directory_reader(
+    directory_path: str, recurse: bool = True, validate: bool = False
+) -> Iterator[ParseResult]:
     """Extract FHIR resources from directory
 
     Read any type of json file, return itemized resources by iterating through Bundles and Lists
@@ -99,13 +123,19 @@ def directory_reader(directory_path: str,
     directory_path = directory_path.expanduser()
 
     try:
-        input_files = [_ for _ in pathlib.Path.glob(directory_path.name) if is_json_extension(_.name)]
+        input_files = [
+            _
+            for _ in pathlib.Path.glob(directory_path.name)
+            if is_json_extension(_.name)
+        ]
     except TypeError:
         input_files = []
 
     if len(input_files) == 0:
         if recurse:
-            input_files = [_ for _ in directory_path.glob('**/*.*') if is_json_extension(_.name)]
+            input_files = [
+                _ for _ in directory_path.glob("**/*.*") if is_json_extension(_.name)
+            ]
 
     # assert len(input_files) > 0, f"No files found in {directory_path.name}"
 
@@ -124,7 +154,9 @@ def directory_reader(directory_path: str,
 def aggregate(metadata_path: pathlib.Path | str) -> dict:
     """Aggregate metadata counts resourceType(count)-count->resourceType(count)."""
 
-    nested_dict: Callable[[], defaultdict[str, defaultdict]] = lambda: defaultdict(defaultdict)
+    nested_dict: Callable[[], defaultdict[str, defaultdict]] = lambda: defaultdict(
+        defaultdict
+    )
 
     if not isinstance(metadata_path, pathlib.Path):
         metadata_path = pathlib.Path(metadata_path)
@@ -132,23 +164,23 @@ def aggregate(metadata_path: pathlib.Path | str) -> dict:
     for path in sorted(metadata_path.glob("*.ndjson")):
         for _ in read_ndjson_file(path):
 
-            resource_type = _['resourceType']
-            if 'count' not in summary[resource_type]:
-                summary[resource_type]['count'] = 0
-            summary[resource_type]['count'] += 1
+            resource_type = _["resourceType"]
+            if "count" not in summary[resource_type]:
+                summary[resource_type]["count"] = 0
+            summary[resource_type]["count"] += 1
 
-            refs = nested_lookup('reference', _)
+            refs = nested_lookup("reference", _)
             for ref in refs:
                 # A codeable reference is an object with a codeable concept and a reference
                 if isinstance(ref, dict):
-                    ref = ref['reference']
-                ref_resource_type = ref.split('/')[0]
-                if 'references' not in summary[resource_type]:
-                    summary[resource_type]['references'] = nested_dict()
-                dst = summary[resource_type]['references'][ref_resource_type]
-                if 'count' not in dst:
-                    dst['count'] = 0
-                dst['count'] += 1
+                    ref = ref["reference"]
+                ref_resource_type = ref.split("/")[0]
+                if "references" not in summary[resource_type]:
+                    summary[resource_type]["references"] = nested_dict()
+                dst = summary[resource_type]["references"][ref_resource_type]
+                if "count" not in dst:
+                    dst["count"] = 0
+                dst["count"] += 1
 
     return summary
 
@@ -176,7 +208,7 @@ def validate_and_transform_graphql_field_name(field_name: str) -> str:
     graphql_field_regex = r"^[_\w][\w]*$"  # \w matches alphanumeric + underscore
 
     # 1. Replace invalid characters with underscores
-    cleaned_name = re.sub(r'[^a-zA-Z0-9_]', '_', field_name)
+    cleaned_name = re.sub(r"[^a-zA-Z0-9_]", "_", field_name)
 
     # 2. Replace non-compliant characters (not alphanumeric or underscore) with a single underscore
     #    This also handles replacing multiple spaces/hyphens with a single underscore

--- a/gen3_tracker/meta/cli.py
+++ b/gen3_tracker/meta/cli.py
@@ -1,4 +1,3 @@
-
 import click
 import pathlib
 import sys
@@ -10,8 +9,13 @@ from gen3_tracker.common import INFO_COLOR, ERROR_COLOR
 
 
 @click.group()
-@click.option('--project_id', default=None, show_default=True,
-              help="Gen3 program-project", envvar=f"{ENV_VARIABLE_PREFIX}PROJECT_ID")
+@click.option(
+    "--project_id",
+    default=None,
+    show_default=True,
+    help="Gen3 program-project",
+    envvar=f"{ENV_VARIABLE_PREFIX}PROJECT_ID",
+)
 @click.pass_context
 def meta(ctx, project_id):
     """Manage the META directory."""
@@ -19,10 +23,20 @@ def meta(ctx, project_id):
 
 
 @meta.command()
-@click.option('--project_id', default=None, show_default=True,
-              help="Gen3 program-project", envvar=f"{ENV_VARIABLE_PREFIX}PROJECT_ID")
-@click.option('--bundle', is_flag=True, help="Create a Bundle file for deleted records.", default=False)
-@click.option('--debug', is_flag=True)
+@click.option(
+    "--project_id",
+    default=None,
+    show_default=True,
+    help="Gen3 program-project",
+    envvar=f"{ENV_VARIABLE_PREFIX}PROJECT_ID",
+)
+@click.option(
+    "--bundle",
+    is_flag=True,
+    help="Create a Bundle file for deleted records.",
+    default=False,
+)
+@click.option("--debug", is_flag=True)
 @click.pass_context
 def init(ctx, project_id, debug, bundle):
     """Initialize the META directory based on the MANIFEST."""
@@ -31,13 +45,19 @@ def init(ctx, project_id, debug, bundle):
         from gen3_tracker.meta.skeleton import update_meta_files
         from gen3_tracker.meta.validator import validate as validate_dir
 
-        with Halo(text='Generating', spinner='line', placement='right', color='white'):
+        with Halo(text="Generating", spinner="line", placement="right", color="white"):
             config: Config = ctx.obj
             if not project_id:
                 project_id = config.gen3.project_id
-            updated_files = update_meta_files(config.dry_run, project_id, create_bundle=bundle)
-        click.secho(f"Updated {len(updated_files)} metadata files.", fg=INFO_COLOR, file=sys.stderr)
-        result = validate_dir('META', project_id)
+            updated_files = update_meta_files(
+                config.dry_run, project_id, create_bundle=bundle
+            )
+        click.secho(
+            f"Updated {len(updated_files)} metadata files.",
+            fg=INFO_COLOR,
+            file=sys.stderr,
+        )
+        result = validate_dir("META", project_id)
         click.secho(result, fg=INFO_COLOR, file=sys.stderr)
 
     except Exception as e:
@@ -48,20 +68,31 @@ def init(ctx, project_id, debug, bundle):
 
 
 @meta.command()
-@click.argument('directory', type=click.Path(exists=True), default='META')
-@click.option('--debug', is_flag=True, default=False, show_default=True, help='Enable debug mode.')
-@click.option('--skip-id-check', is_flag=True, default=False, show_default=True, help='Skip checking that resource IDs are valid for the project.')
+@click.argument("directory", type=click.Path(exists=True), default="META")
+@click.option(
+    "--debug", is_flag=True, default=False, show_default=True, help="Enable debug mode."
+)
+@click.option(
+    "--skip-id-check",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Skip checking that resource IDs are valid for the project.",
+)
 @click.pass_obj
 def validate(ctx, directory, debug, skip_id_check):
     """Validate FHIR data"""
     try:
         from gen3_tracker.meta.validator import validate as validate_dir
-        with Halo(text='Validating', spinner='line', placement='right', color='white'):
+
+        with Halo(text="Validating", spinner="line", placement="right", color="white"):
             project_id = ctx.gen3.project_id if not skip_id_check else None
             result = validate_dir(directory, project_id=project_id)
         click.secho(result.resources, fg=INFO_COLOR, file=sys.stderr)
         for _ in result.exceptions:
-            click.secho(f"{_.path}:{_.offset} {_.exception}", fg=ERROR_COLOR, file=sys.stderr)
+            click.secho(
+                f"{_.path}:{_.offset} {_.exception}", fg=ERROR_COLOR, file=sys.stderr
+            )
         if result.exceptions:
             if debug or ctx.debug:
                 raise result.exceptions[0].exception
@@ -73,13 +104,22 @@ def validate(ctx, directory, debug, skip_id_check):
 
 
 @meta.command("graph")
-@click.argument("directory_path",
-                type=click.Path(exists=True, file_okay=False),
-                default="META", required=False)
-@click.argument("output_path",
-                type=click.Path(file_okay=True),
-                default="meta.html", required=False)
-@click.option('--browser', default=False, show_default=True, is_flag=True, help='Open the graph in a browser.')
+@click.argument(
+    "directory_path",
+    type=click.Path(exists=True, file_okay=False),
+    default="META",
+    required=False,
+)
+@click.argument(
+    "output_path", type=click.Path(file_okay=True), default="meta.html", required=False
+)
+@click.option(
+    "--browser",
+    default=False,
+    show_default=True,
+    is_flag=True,
+    help="Open the graph in a browser.",
+)
 @click.pass_obj
 def render_graph(config: Config, directory_path: str, output_path: str, browser: bool):
     """Render metadata as a network graph.
@@ -92,12 +132,18 @@ def render_graph(config: Config, directory_path: str, output_path: str, browser:
         from gen3_tracker.meta.visualizer import create_network_graph
         import webbrowser
 
-        assert pathlib.Path(directory_path).exists(), f"Directory {directory_path} does not exist."
-        with Halo(text='Graphing', spinner='line', placement='right', color='white'):
+        assert pathlib.Path(
+            directory_path
+        ).exists(), f"Directory {directory_path} does not exist."
+        with Halo(text="Graphing", spinner="line", placement="right", color="white"):
             output_path = pathlib.Path(output_path)
             create_network_graph(directory_path, output_path)
             url = f"file://{output_path.absolute()}"
-        click.secho(f"Saved {output_path}, open it in your browser to view the network.", fg=INFO_COLOR, file=sys.stderr)
+        click.secho(
+            f"Saved {output_path}, open it in your browser to view the network.",
+            fg=INFO_COLOR,
+            file=sys.stderr,
+        )
         if browser:
             webbrowser.open(url)
     except Exception as e:
@@ -107,19 +153,45 @@ def render_graph(config: Config, directory_path: str, output_path: str, browser:
 
 
 @meta.command("dataframe")
-@click.argument('data_type',
-                required=True,
-                type=click.Choice(['Specimen', 'DocumentReference', 'ResearchSubject', "MedicationAdministration", "GroupMember"]),
-                default=None)
-@click.argument("directory_path",
-                type=click.Path(exists=True, file_okay=False),
-                default="./META", required=False)
-@click.argument("output_path",
-                type=click.Path(file_okay=True), required=False)
-@click.option('--dtale', 'launch_dtale', default=False, show_default=True, is_flag=True, help='Open the graph in a browser using the dtale package for interactive data exploration.')
-@click.option('--debug', is_flag=True)
+@click.argument(
+    "data_type",
+    required=True,
+    type=click.Choice(
+        [
+            "Specimen",
+            "DocumentReference",
+            "ResearchSubject",
+            "MedicationAdministration",
+            "GroupMember",
+        ]
+    ),
+    default=None,
+)
+@click.argument(
+    "directory_path",
+    type=click.Path(exists=True, file_okay=False),
+    default="./META",
+    required=False,
+)
+@click.argument("output_path", type=click.Path(file_okay=True), required=False)
+@click.option(
+    "--dtale",
+    "launch_dtale",
+    default=False,
+    show_default=True,
+    is_flag=True,
+    help="Open the graph in a browser using the dtale package for interactive data exploration.",
+)
+@click.option("--debug", is_flag=True)
 @click.pass_obj
-def render_df(config: Config, directory_path: str, output_path: str, launch_dtale: bool, data_type: str, debug: bool):
+def render_df(
+    config: Config,
+    directory_path: str,
+    output_path: str,
+    launch_dtale: bool,
+    data_type: str,
+    debug: bool,
+):
     """Render a metadata dataframe.
 
     \b
@@ -128,10 +200,12 @@ def render_df(config: Config, directory_path: str, output_path: str, launch_dtal
     """
     try:
         from gen3_tracker.meta.dataframer import create_dataframe
+
         df = create_dataframe(directory_path, config.work_dir, data_type)
 
         if launch_dtale:
             import dtale
+
             dtale.show(df, subprocess=False, open_browser=True, port=40000)
         else:
             # export to csv
@@ -144,4 +218,4 @@ def render_df(config: Config, directory_path: str, output_path: str, launch_dtal
             raise
 
 
-meta.add_command(render_df, name='df')
+meta.add_command(render_df, name="df")

--- a/gen3_tracker/meta/dataframer.py
+++ b/gen3_tracker/meta/dataframer.py
@@ -383,7 +383,9 @@ class LocalFHIRDatabase:
                             value = None
 
                         assert value is not None, f"no value for {resource['id']}"
-                        procedure[validate_and_transform_graphql_field_name(code)] = value
+                        procedure[validate_and_transform_graphql_field_name(code)] = (
+                            value
+                        )
 
                         continue
 
@@ -504,7 +506,9 @@ class LocalFHIRDatabase:
                 for condition in conditions:
                     for k, v in traverse(condition).items():
                         if k not in set(["condition_id", "condition_identifier"]):
-                            flat_research_subject[validate_and_transform_graphql_field_name(k)] = v
+                            flat_research_subject[
+                                validate_and_transform_graphql_field_name(k)
+                            ] = v
 
             yield flat_research_subject
 
@@ -637,7 +641,9 @@ class LocalFHIRDatabase:
             # for each member in a group, yield a group member dict
             for member_id in group_resource.members:
                 # unique primary key from group and member ids
-                group_member_id = str(uuid.uuid5(ACED_NAMESPACE, simplified_group["id"] + "," + member_id))
+                group_member_id = str(
+                    uuid.uuid5(ACED_NAMESPACE, simplified_group["id"] + "," + member_id)
+                )
 
                 # group member dict composed of a simple group dict, unique primary key, and unique member_id
                 yield {
@@ -678,9 +684,7 @@ def create_dataframe(
         )
 
     if df.empty:
-        raise ValueError(
-            f"Dataframe is empty, are there any {data_type} resources?"
-        )
+        raise ValueError(f"Dataframe is empty, are there any {data_type} resources?")
 
     prefix = inflection.underscore(data_type)
     df = df.rename(columns={col: f"{prefix}_{col}" for col in df.columns})

--- a/gen3_tracker/meta/dataframer.py
+++ b/gen3_tracker/meta/dataframer.py
@@ -742,7 +742,7 @@ def get_subject(db: LocalFHIRDatabase, resource: dict) -> dict:
 def get_resources_by_reference(
     db: LocalFHIRDatabase, resource_type: str, reference_field: str, reference_type: str
 ) -> dict[str, list]:
-    """given a set of rescode ources of type resource_type, map each unique reference in reference field of type reference_type to its associated resources
+    """given a set of resources of type resource_type, map each unique reference in reference field of type reference_type to its associated resources
     ex: use all Observations with a Specimen focus, map Specimen IDs to its list of associated Observations and return the map
     """
 

--- a/gen3_tracker/meta/entities.py
+++ b/gen3_tracker/meta/entities.py
@@ -308,7 +308,7 @@ class SimplifiedFHIR(BaseModel):
                     "identifier"
 
                     if i == 0 or identifier.get("use", "") == "official"
-                    else identifier.get("system").split("/")[-1]
+                    else "identifier_" + validate_and_transform_graphql_field_name(identifier.get("system").split("/")[-1])
                 ): identifier.get("value")
                 for i, identifier in enumerate(identifiers)
             }

--- a/gen3_tracker/meta/entities.py
+++ b/gen3_tracker/meta/entities.py
@@ -306,9 +306,11 @@ class SimplifiedFHIR(BaseModel):
             base_identifier = {
                 (
                     "identifier"
-
                     if i == 0 or identifier.get("use", "") == "official"
-                    else "identifier_" + validate_and_transform_graphql_field_name(identifier.get("system").split("/")[-1])
+                    else "identifier_"
+                    + validate_and_transform_graphql_field_name(
+                        identifier.get("system").split("/")[-1]
+                    )
                 ): identifier.get("value")
                 for i, identifier in enumerate(identifiers)
             }
@@ -326,7 +328,9 @@ class SimplifiedFHIR(BaseModel):
 
         # update the key if code information is available
         if self.resource.get("code", {}).get("text", None):
-            source = validate_and_transform_graphql_field_name(self.resource["code"]["text"])
+            source = validate_and_transform_graphql_field_name(
+                self.resource["code"]["text"]
+            )
         return {source: value}
 
 

--- a/gen3_tracker/meta/skeleton.py
+++ b/gen3_tracker/meta/skeleton.py
@@ -27,30 +27,37 @@ from gen3_tracker.git import DVC, run_command, dvc_data
 
 def _get_system(identifier: str, project_id: str):
     """Return system component of simplified identifier"""
-    if '#' in identifier:
-        return identifier.split('#')[0]
-    if '|' in identifier:
-        return identifier.split('|')[0]
+    if "#" in identifier:
+        return identifier.split("#")[0]
+    if "|" in identifier:
+        return identifier.split("|")[0]
     # default
     return f"https://aced-idp.org/{project_id}"
 
 
 def meta_index():
     """Read all the ndjson files in the `META` directory and create a dictionary with the id as the key and the official identifier as the value"""
-    meta_dir = pathlib.Path('META')
+    meta_dir = pathlib.Path("META")
     id_dict = {}
 
-    for file in meta_dir.glob('*.ndjson'):
-        with open(file, 'r') as f:
+    for file in meta_dir.glob("*.ndjson"):
+        with open(file, "r") as f:
             for line in f:
                 record = orjson.loads(line)
-                _id = record.get('id')
-                resource_type = record.get('resourceType')
-                if resource_type == 'Bundle':
+                _id = record.get("id")
+                resource_type = record.get("resourceType")
+                if resource_type == "Bundle":
                     break
-                official_identifier = next((identifier.get('value') for identifier in record.get('identifier', []) if identifier.get('use') == 'official'), None)
-                if not official_identifier and record.get('identifier'):
-                    official_identifier = record['identifier'][0]['value']
+                official_identifier = next(
+                    (
+                        identifier.get("value")
+                        for identifier in record.get("identifier", [])
+                        if identifier.get("use") == "official"
+                    ),
+                    None,
+                )
+                if not official_identifier and record.get("identifier"):
+                    official_identifier = record["identifier"][0]["value"]
 
                 if _id and official_identifier:
                     id_dict[f"{resource_type}/{_id}"] = official_identifier
@@ -60,14 +67,14 @@ def meta_index():
 
 def get_data_from_meta() -> Generator[int, None, None]:
     """Read all the ndjson files in the `META` directory and return a generator that produces all records"""
-    meta_dir = pathlib.Path('META')
+    meta_dir = pathlib.Path("META")
 
-    for file in meta_dir.glob('*.ndjson'):
-        with open(file, 'r') as f:
+    for file in meta_dir.glob("*.ndjson"):
+        with open(file, "r") as f:
             for line in f:
                 record = orjson.loads(line)
-                resource_type = record.get('resourceType')
-                if resource_type == 'Bundle':
+                resource_type = record.get("resourceType")
+                if resource_type == "Bundle":
                     break
 
                 yield record
@@ -75,11 +82,13 @@ def get_data_from_meta() -> Generator[int, None, None]:
 
 def update_document_reference(document_reference: DocumentReference, dvc_data: DVC):
     """Update document reference with index record."""
-    assert document_reference.resource_type == 'DocumentReference'
-    assert dvc_data.out.object_id == document_reference.id, f"{dvc_data['did']} != {document_reference.id}"
+    assert document_reference.resource_type == "DocumentReference"
+    assert (
+        dvc_data.out.object_id == document_reference.id
+    ), f"{dvc_data['did']} != {document_reference.id}"
     assert dvc_data.out.modified, f"dvc_data missing modified: {dvc_data}"
-    document_reference.docStatus = 'final'
-    document_reference.status = 'current'
+    document_reference.docStatus = "final"
+    document_reference.status = "current"
 
     document_reference.date = dvc_data.out.modified
 
@@ -89,17 +98,17 @@ def update_document_reference(document_reference: DocumentReference, dvc_data: D
     else:
         source_path = dvc_data.out.source_url
 
-    source_path = source_path.replace('////', '///')
+    source_path = source_path.replace("////", "///")
 
     attachment.extension = [
         {
             "url": f"http://aced-idp.org/fhir/StructureDefinition/{dvc_data.out.hash}",
-            "valueString": dvc_data.out.hash_value
+            "valueString": dvc_data.out.hash_value,
         },
         {
             "url": "http://aced-idp.org/fhir/StructureDefinition/source_path",
-            "valueUrl": source_path
-        }
+            "valueUrl": source_path,
+        },
     ]
     attachment.contentType = dvc_data.out.mime
 
@@ -114,14 +123,23 @@ def update_document_reference(document_reference: DocumentReference, dvc_data: D
     document_reference.content = [content]
 
 
-def create_id_from_strings(resource_type: str, project_id: str, identifier_string: str) -> str:
+def create_id_from_strings(
+    resource_type: str, project_id: str, identifier_string: str
+) -> str:
     """Create an id from strings."""
     if not identifier_string:
         return None
-    return str(uuid.uuid5(ACED_NAMESPACE, f"{project_id}/{resource_type}/{_get_system(identifier_string, project_id)}|{identifier_string}"))
+    return str(
+        uuid.uuid5(
+            ACED_NAMESPACE,
+            f"{project_id}/{resource_type}/{_get_system(identifier_string, project_id)}|{identifier_string}",
+        )
+    )
 
 
-def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> list[Resource]:
+def create_skeleton(
+    dvc: dict, project_id: str, meta_index: set[str] = []
+) -> list[Resource]:
     """
     Create a skeleton graph for document and ancestors from a set of identifiers.
     """
@@ -137,77 +155,124 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
     document_reference_id = dvc.out.set_object_id(project_id=project_id)
 
     assert project_id, "project_id required"
-    assert project_id.count('-') == 1, "project_id must be of the form program-project"
-    program, project = project_id.split('-')
+    assert project_id.count("-") == 1, "project_id must be of the form program-project"
+    program, project = project_id.split("-")
 
-    research_study = research_subject = observation = specimen = patient = task = document_reference = None
+    research_study = research_subject = observation = specimen = patient = task = (
+        document_reference
+    ) = None
 
     # check if we have already created the resources
 
-    research_study_id = create_id_from_strings(resource_type='ResearchStudy', project_id=project_id, identifier_string=project_id)
-    specimen_id = create_id_from_strings(resource_type='Specimen', project_id=project_id, identifier_string=specimen_identifier)
-    patient_id = create_id_from_strings(resource_type='Patient', project_id=project_id, identifier_string=patient_identifier)
-    task_id = create_id_from_strings(resource_type='Task', project_id=project_id, identifier_string=task_identifier)
-    observation_id = create_id_from_strings(resource_type='Observation', project_id=project_id, identifier_string=observation_identifier)
+    research_study_id = create_id_from_strings(
+        resource_type="ResearchStudy",
+        project_id=project_id,
+        identifier_string=project_id,
+    )
+    specimen_id = create_id_from_strings(
+        resource_type="Specimen",
+        project_id=project_id,
+        identifier_string=specimen_identifier,
+    )
+    patient_id = create_id_from_strings(
+        resource_type="Patient",
+        project_id=project_id,
+        identifier_string=patient_identifier,
+    )
+    task_id = create_id_from_strings(
+        resource_type="Task", project_id=project_id, identifier_string=task_identifier
+    )
+    observation_id = create_id_from_strings(
+        resource_type="Observation",
+        project_id=project_id,
+        identifier_string=observation_identifier,
+    )
 
-    _ = f'ResearchStudy/{research_study_id}'
+    _ = f"ResearchStudy/{research_study_id}"
     if _ in meta_index:
         research_study = meta_index[_]
-    _ = f'Specimen/{specimen_id}'
+    _ = f"Specimen/{specimen_id}"
     if _ in meta_index:
         specimen = meta_index[_]
 
-    _ = f'Patient/{patient_id}'
+    _ = f"Patient/{patient_id}"
     if _ in meta_index:
         patient = meta_index[_]
 
-    _ = f'Task/{task_id}'
+    _ = f"Task/{task_id}"
     if _ in meta_index:
         task = meta_index[_]
 
-    _ = f'Observation/{observation_id}'
+    _ = f"Observation/{observation_id}"
     if _ in meta_index:
         observation = meta_index[_]
 
     # create entities
 
-    document_reference = DocumentReference(status='current', content=[{'attachment': {'url': "file://"}}])
+    document_reference = DocumentReference(
+        status="current", content=[{"attachment": {"url": "file://"}}]
+    )
     document_reference.id = document_reference_id
     document_reference.identifier = [
-
-        Identifier(value=document_reference_id, system=_get_system(document_reference_id, project_id=project_id),
-                   use='official')]
+        Identifier(
+            value=document_reference_id,
+            system=_get_system(document_reference_id, project_id=project_id),
+            use="official",
+        )
+    ]
     update_document_reference(document_reference, dvc)
 
     if not research_study:
-        research_study = ResearchStudy(status='active')
+        research_study = ResearchStudy(status="active")
         research_study.description = f"Skeleton ResearchStudy for {project_id}"
         research_study.identifier = [
-            Identifier(value=project_id, system=_get_system(project_id, project_id=project_id),
-                       use='official')]
+            Identifier(
+                value=project_id,
+                system=_get_system(project_id, project_id=project_id),
+                use="official",
+            )
+        ]
         research_study.id = create_resource_id(research_study, project_id)
 
     if not patient and patient_identifier:
         patient = Patient()
-        patient.identifier = [Identifier(value=patient_identifier, system=_get_system(patient_identifier, project_id=project_id), use='official')]
+        patient.identifier = [
+            Identifier(
+                value=patient_identifier,
+                system=_get_system(patient_identifier, project_id=project_id),
+                use="official",
+            )
+        ]
         patient.id = create_resource_id(patient, project_id)
 
         research_subject = ResearchSubject(
-            status='active',
-            study={'reference': f"ResearchStudy/{research_study_id}"},
-            subject={'reference': f"Patient/{patient.id}"}
+            status="active",
+            study={"reference": f"ResearchStudy/{research_study_id}"},
+            subject={"reference": f"Patient/{patient.id}"},
         )
-        research_subject.identifier = [Identifier(value=patient_identifier, system=_get_system(patient_identifier, project_id=project_id), use='official')]
+        research_subject.identifier = [
+            Identifier(
+                value=patient_identifier,
+                system=_get_system(patient_identifier, project_id=project_id),
+                use="official",
+            )
+        ]
         research_subject.id = create_resource_id(research_subject, project_id)
         patient_id = patient.id
 
     if not observation and observation_identifier:
-        observation = Observation(status='final', code={'text': 'unknown'})
-        observation.identifier = [Identifier(value=observation_identifier, system=_get_system(observation_identifier, project_id=project_id), use='official')]
+        observation = Observation(status="final", code={"text": "unknown"})
+        observation.identifier = [
+            Identifier(
+                value=observation_identifier,
+                system=_get_system(observation_identifier, project_id=project_id),
+                use="official",
+            )
+        ]
         observation.id = create_resource_id(observation, project_id)
 
         assert patient, "patient required for observation"
-        observation.subject = {'reference': f"Patient/{patient_id}"}
+        observation.subject = {"reference": f"Patient/{patient_id}"}
 
     if not specimen and specimen_identifier:
 
@@ -216,17 +281,28 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
         # exit(1)
 
         specimen = Specimen()
-        specimen.identifier = [Identifier(value=specimen_identifier, system=_get_system(specimen_identifier, project_id=project_id), use='official')]
+        specimen.identifier = [
+            Identifier(
+                value=specimen_identifier,
+                system=_get_system(specimen_identifier, project_id=project_id),
+                use="official",
+            )
+        ]
         specimen.id = create_resource_id(specimen, project_id)
         specimen_id = specimen.id
 
         assert patient, "patient required for specimen"
-        specimen.subject = {'reference': f"Patient/{patient_id}"}
+        specimen.subject = {"reference": f"Patient/{patient_id}"}
 
     if not task and task_identifier:
-        task = Task(intent='unknown', status='completed')
-        task.identifier = [Identifier(value=task_identifier, system=_get_system(task_identifier, project_id=project_id),
-                                      use='official')]
+        task = Task(intent="unknown", status="completed")
+        task.identifier = [
+            Identifier(
+                value=task_identifier,
+                system=_get_system(task_identifier, project_id=project_id),
+                use="official",
+            )
+        ]
         task.id = create_resource_id(task, project_id)
         task_id = task.id
 
@@ -234,9 +310,9 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
 
     # assign subject, specimen of observation
     if observation and specimen and not observation.specimen:
-        observation.specimen = {'reference': f"Specimen/{specimen_id}"}
+        observation.specimen = {"reference": f"Specimen/{specimen_id}"}
     if observation and patient and not observation.subject:
-        observation.subject = {'reference': f"Patient/{patient_id}"}
+        observation.subject = {"reference": f"Patient/{patient_id}"}
 
     if task:
         task.input = []
@@ -244,52 +320,67 @@ def create_skeleton(dvc: dict, project_id: str, meta_index: set[str] = []) -> li
             task.input.append(
                 TaskInput(
                     valueReference={"reference": f"Specimen/{specimen.id}"},
-                    type={'text': 'Specimen'}
+                    type={"text": "Specimen"},
                 )
             )
         if patient:
             task.input.append(
                 TaskInput(
-                    valueReference={'reference': f"Patient/{patient.id}"},
-                    type={'text': 'Patient'}
+                    valueReference={"reference": f"Patient/{patient.id}"},
+                    type={"text": "Patient"},
                 )
             )
         task.output = [
             TaskOutput(
-                valueReference={'reference': f"DocumentReference/{document_reference.id}"},
-                type={'text': 'DocumentReference'})
+                valueReference={
+                    "reference": f"DocumentReference/{document_reference.id}"
+                },
+                type={"text": "DocumentReference"},
+            )
         ]
 
     # assign document reference subject
     if observation:
-        document_reference.subject = {'reference': f"Observation/{observation_id}"}
+        document_reference.subject = {"reference": f"Observation/{observation_id}"}
     if specimen and not document_reference.subject:
-        document_reference.subject = {'reference': f"Specimen/{specimen_id}"}
+        document_reference.subject = {"reference": f"Specimen/{specimen_id}"}
     if patient and not document_reference.subject:
-        document_reference.subject = {'reference': f"Patient/{patient_id}"}
+        document_reference.subject = {"reference": f"Patient/{patient_id}"}
     if not document_reference.subject:
-        document_reference.subject = {'reference': f"ResearchStudy/{research_study_id}"}
+        document_reference.subject = {"reference": f"ResearchStudy/{research_study_id}"}
 
-    return [_ for _ in [research_study, research_subject, patient, observation, specimen, task, document_reference] if _ and not isinstance(_, str)]
+    return [
+        _
+        for _ in [
+            research_study,
+            research_subject,
+            patient,
+            observation,
+            specimen,
+            task,
+            document_reference,
+        ]
+        if _ and not isinstance(_, str)
+    ]
 
 
 def update_meta_files(dry_run=False, project_id=None, create_bundle=False) -> list[str]:
     """Maintain the META directory."""
     assert project_id, "project_id required"
-    manifest_path = pathlib.Path('MANIFEST')
-    dvc_files = [_ for _ in manifest_path.rglob('*.dvc')]
+    manifest_path = pathlib.Path("MANIFEST")
+    dvc_files = [_ for _ in manifest_path.rglob("*.dvc")]
 
-    before_meta_files = [_ for _ in pathlib.Path('META').glob('*.ndjson')]
+    before_meta_files = [_ for _ in pathlib.Path("META").glob("*.ndjson")]
     before_meta_index = set(list(meta_index().keys()))
     emitted_already = []
 
     if not dvc_files:
         # remove the DocumentReference file if it exists
-        document_reference_path = pathlib.Path('META/DocumentReference.ndjson')
+        document_reference_path = pathlib.Path("META/DocumentReference.ndjson")
         if document_reference_path.exists():
             document_reference_path.unlink()
 
-    with EmitterContextManager('META') as emitter:
+    with EmitterContextManager("META") as emitter:
         for _ in dvc_data(dvc_files):
             resources = create_skeleton(_, project_id, meta_index())
             for resource in resources:
@@ -306,33 +397,48 @@ def update_meta_files(dry_run=False, project_id=None, create_bundle=False) -> li
     if orphaned_meta_index:
         # create a bundle to tell server about deletes
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-        bundle = Bundle(type='transaction', timestamp=now)
+        bundle = Bundle(type="transaction", timestamp=now)
 
-        bundle.identifier = Identifier(value=project_id, system="https://aced-idp.org/project_id", use='official')
+        bundle.identifier = Identifier(
+            value=project_id, system="https://aced-idp.org/project_id", use="official"
+        )
         bundle.id = create_resource_id(bundle, project_id)
 
         bundle.entry = []
-        outcome = OperationOutcome(issue=[{'severity': 'warning', 'code': 'processing', 'diagnostics': 'Meta data items no longer in study.'}])
+        outcome = OperationOutcome(
+            issue=[
+                {
+                    "severity": "warning",
+                    "code": "processing",
+                    "diagnostics": "Meta data items no longer in study.",
+                }
+            ]
+        )
         bundle.issues = outcome
 
         for _ in orphaned_meta_index:
             bundle_entry = BundleEntry()
-            bundle_entry.request = BundleEntryRequest(url=_, method='DELETE')
+            bundle_entry.request = BundleEntryRequest(url=_, method="DELETE")
             bundle.entry.append(bundle_entry)
 
         if create_bundle:
-            with EmitterContextManager('META') as emitter:
-                emitter.emit(bundle.resource_type, file_mode='a').write(
+            with EmitterContextManager("META") as emitter:
+                emitter.emit(bundle.resource_type, file_mode="a").write(
                     bundle.json(option=orjson.OPT_APPEND_NEWLINE)
                 )
         else:
             if len(orphaned_meta_index):
-                print(f"Records were orphaned meta index: {orphaned_meta_index}", file=sys.stderr)
+                print(
+                    f"Records were orphaned meta index: {orphaned_meta_index}",
+                    file=sys.stderr,
+                )
 
-    after_meta_files = [_ for _ in pathlib.Path('META').glob('*.ndjson')]
+    after_meta_files = [_ for _ in pathlib.Path("META").glob("*.ndjson")]
     new_meta_files = [str(_) for _ in after_meta_files if _ not in before_meta_files]
 
     if new_meta_files:
-        run_command(f'git add {" ".join(new_meta_files)}', dry_run=dry_run, no_capture=True)
+        run_command(
+            f'git add {" ".join(new_meta_files)}', dry_run=dry_run, no_capture=True
+        )
 
     return after_meta_files

--- a/gen3_tracker/meta/validator.py
+++ b/gen3_tracker/meta/validator.py
@@ -24,7 +24,7 @@ class ValidateDirectoryResult(BaseModel):
     def model_dump(self):
         """
 
-         temporary until we switch to pydantic2
+        temporary until we switch to pydantic2
         """
         for _ in self.exceptions:
             _.exception = str(_.exception)
@@ -36,10 +36,14 @@ def _check_coding(self: Coding, *args, **kwargs):
     """MonkeyPatch replacement for dict(), check Coding."""
     # note `self` is the Coding
     assert self.code, f"Missing `code` {self}"
-    assert (not self.code.startswith("http")), f"`code` should _not_ be a url http {self.code}"
+    assert not self.code.startswith(
+        "http"
+    ), f"`code` should _not_ be a url http {self.code}"
     assert ":" not in self.code, f"`code` should not contain ':' {self.code}"
     assert self.system, f"Missing `system` {self}"
-    assert "%" not in self.system, f"`system` should be a simple url without uuencoding {self.system}"
+    assert (
+        "%" not in self.system
+    ), f"`system` should be a simple url without uuencoding {self.system}"
     parsed = urlparse(self.system)
     assert parsed.scheme, f"`system` is not a URI {self}"
     assert self.display, f"Missing `display` {self}"
@@ -54,7 +58,9 @@ def _check_identifier(self: Identifier, *args, **kwargs):
     assert self.system, f"Missing `system` {self}"
     parsed = urlparse(self.system)
     assert parsed.scheme, f"`system` is not a URI {self}"
-    assert "%" not in self.system, f"`system` should be a simple url without uuencoding {self.system}"
+    assert (
+        "%" not in self.system
+    ), f"`system` should be a simple url without uuencoding {self.system}"
     # call the original dict() method
     return orig_identifier_dict(self, *args, **kwargs)
 
@@ -63,9 +69,11 @@ def _check_reference(self: Reference, *args, **kwargs):
     """MonkeyPatch replacement for dict(), check Reference."""
     # note `self` is the Identifier
     assert self.reference, f"Missing `reference` {self}"
-    assert '/' in self.reference, f"Does not appear to be Relative reference {self}"
-    assert 'http' not in self.reference, f"Absolute references not supported {self}"
-    assert len(self.reference.split('/')) == 2, f"Does not appear to be Relative reference {self}"
+    assert "/" in self.reference, f"Does not appear to be Relative reference {self}"
+    assert "http" not in self.reference, f"Absolute references not supported {self}"
+    assert (
+        len(self.reference.split("/")) == 2
+    ), f"Does not appear to be Relative reference {self}"
 
     # call the original dict() method
     return orig_reference_dict(self, *args, **kwargs)
@@ -99,7 +107,7 @@ def validate(directory_path: pathlib.Path, project_id=None) -> ValidateDirectory
 
         _ = parse_result.resource
         ids.append(f"{_.resource_type}/{_.id}")
-        nested_references = nested_lookup('reference', parse_result.json_obj)
+        nested_references = nested_lookup("reference", parse_result.json_obj)
         # https://www.hl7.org/fhir/medicationrequest-definitions.html#MedicationRequest.medication
         # is a reference to a Medication resource https://www.hl7.org/fhir/references.html#CodeableReference
         # so it has a reference.reference form, strip it out
@@ -113,7 +121,9 @@ def validate(directory_path: pathlib.Path, project_id=None) -> ValidateDirectory
     ids = set(ids)
     if not references.issubset(ids):
         _ = Exception(f"references not found {references - ids}")
-        _ = ParseResult(resource=None, exception=_, path=directory_path, resource_id=None)
+        _ = ParseResult(
+            resource=None, exception=_, path=directory_path, resource_id=None
+        )
         exceptions.append(_)
     if len(ids) != len(ids_list):
         # Create a Counter object from ids_list
@@ -122,10 +132,14 @@ def validate(directory_path: pathlib.Path, project_id=None) -> ValidateDirectory
         duplicate_ids = [id_ for id_, count in counter.items() if count > 1]
         # log it
         _ = Exception(f"Duplicate ids found {duplicate_ids}")
-        _ = ParseResult(resource=None, exception=_, path=directory_path, resource_id=None)
+        _ = ParseResult(
+            resource=None, exception=_, path=directory_path, resource_id=None
+        )
         exceptions.append(_)
 
-    return ValidateDirectoryResult(resources={'summary': dict(resources)}, exceptions=exceptions)
+    return ValidateDirectoryResult(
+        resources={"summary": dict(resources)}, exceptions=exceptions
+    )
 
 
 #

--- a/gen3_tracker/meta/visualizer.py
+++ b/gen3_tracker/meta/visualizer.py
@@ -4,19 +4,21 @@ from pyvis.network import Network
 
 def _container():
     """Create a pyvis container."""
-    return Network(notebook=True, cdn_resources='in_line')  # filter_menu=True, select_menu=True
+    return Network(
+        notebook=True, cdn_resources="in_line"
+    )  # filter_menu=True, select_menu=True
 
 
 def _load(net: Network, aggregation: dict) -> Network:
     """Load the aggregation into the visualization network."""
     # add vertices
     for resource_type, _ in aggregation.items():
-        assert 'count' in _, _
+        assert "count" in _, _
         net.add_node(resource_type, label=f"{resource_type}/{_['count']}")
     # add edges
     for resource_type, _ in aggregation.items():
-        for ref in _.get('references', {}):
-            count = _['references'][ref]['count']
+        for ref in _.get("references", {}):
+            count = _["references"][ref]["count"]
             net.add_edge(resource_type, ref, title=count, value=count)
     return net
 
@@ -32,4 +34,4 @@ def create_network_graph(directory_path: str, output_path: str):
     # Load it into a pyvis
     net = _load(_container(), aggregation)
     net.save_graph(str(output_path))
-    net.show_buttons(filter_=['physics'])
+    net.show_buttons(filter_=["physics"])

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name='gen3_tracker',
-    version='0.0.7rc23',
+    version='0.0.7rc24',
     description='A CLI for adding version control to Gen3 data submission projects.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/integration/test_end_to_end_workflow.py
+++ b/tests/integration/test_end_to_end_workflow.py
@@ -5,7 +5,7 @@ import yaml
 from click.testing import CliRunner
 
 from gen3_tracker.config import ensure_auth, default
-from gen3_tracker.git import DVC, run_command
+from gen3_tracker.git import DVC
 from pathlib import Path
 from tests.integration import validate_document_in_elastic, validate_document_in_grip
 from tests import run


### PR DESCRIPTION
## Description 
In the Specimens for aced-evotypes, there were multiple identifiers and one identifier was created as a field name but wasn't transformed to be GraphQL compliant. Made sure it was.

Tiny change in first commit, rest is just linting.

## Validation Steps
- [x] Dataframe all SMMART data and confirm that identifier field names populate as expected (eg in Specimen)
- [x] Dataframe all BForePC data and confirm that field names populate as expected
- [x] change etl tag to `bugfix_secondary-identifiers`, `g3t push --step publish` aced-evotypes + restart guppy successfully on local

## Deployment Steps before Merge
- [x] change etl tag to `bugfix_secondary-identifiers`, push `g3t push --step publish` aced-evotypes upload with Guppy restarted
