### PR TITLE
adds PathAggregation

### DIFF
--- a/gen3_tracker/meta/cli.py
+++ b/gen3_tracker/meta/cli.py
@@ -109,7 +109,7 @@ def render_graph(config: Config, directory_path: str, output_path: str, browser:
 @meta.command("dataframe")
 @click.argument('data_type',
                 required=True,
-                type=click.Choice(['Specimen', 'DocumentReference', 'ResearchSubject', "MedicationAdministration", "GroupMember"]),
+                type=click.Choice(['Specimen', 'DocumentReference', 'ResearchSubject', "MedicationAdministration", "GroupMember", "PathAggregation"]),
                 default=None)
 @click.argument("directory_path",
                 type=click.Path(exists=True, file_okay=False),

--- a/gen3_tracker/meta/dataframer.py
+++ b/gen3_tracker/meta/dataframer.py
@@ -552,12 +552,12 @@ class LocalFHIRDatabase:
 
             # 1) ROOT BUCKET: always accumulate to "/" for this path
             file_count, total_size = aggregator["/"]
-            aggregator["/"] = (file_count + 1, total_size + int(size or 0))
+            aggregator["/"] = (file_count + 1, total_size + int(size))
 
             # 2) DIRECTORY PREFIXES: '/a', '/a/b', ... (if any)
             for prefix in path_prefixes(path_n):
                 file_count, total_size = aggregator[prefix]
-                aggregator[prefix] = (file_count + 1, total_size + int(size or 0))
+                aggregator[prefix] = (file_count + 1, total_size + int(size))
 
         # now yield each path aggregation result
         for path, (file_count, total_size) in aggregator.items():

--- a/gen3_tracker/meta/dataframer.py
+++ b/gen3_tracker/meta/dataframer.py
@@ -529,6 +529,46 @@ class LocalFHIRDatabase:
 
             yield flat_medication_administration
 
+    def path_aggregation(self) -> Generator[dict, None, None]:
+        """Generator that aggregates file count and size for each DocumentReference
+        """
+        from gen3_tracker.meta.path_aggregation import normalize_path, path_prefixes, aggregator
+        aggregator.clear()  # clear previous state, if any
+        # retrieve all document references
+        flattened_document_references_df = self.flattened_document_references()
+        # aggregate file count and size for each path prefix, including root "/"
+        for document_reference in flattened_document_references_df:
+            file_name = document_reference.get("url")
+            file_name = file_name.split("://", 1)[-1]  # strip scheme if any
+            size = document_reference.get("size")
+            if not file_name:
+                raise ValueError(f"DocumentReference {document_reference} missing file_name")
+            if not size:
+                raise ValueError(f"DocumentReference {document_reference} missing size")
+
+            path_n = normalize_path(file_name)
+            if not path_n:
+                continue
+
+            # 1) ROOT BUCKET: always accumulate to "/" for this path
+            file_count, total_size = aggregator["/"]
+            aggregator["/"] = (file_count + 1, total_size + int(size or 0))
+
+            # 2) DIRECTORY PREFIXES: '/a', '/a/b', ... (if any)
+            for prefix in path_prefixes(path_n):
+                file_count, total_size = aggregator[prefix]
+                aggregator[prefix] = (file_count + 1, total_size + int(size or 0))
+
+        # now yield each path aggregation result
+        for path, (file_count, total_size) in aggregator.items():
+            yield {
+                # dataframes need an id column, so create a UUID based on db_name+path
+                "id": str(uuid.uuid5(ACED_NAMESPACE, f"{self.db_name}{path}")),
+                "path": path,
+                "file_count": file_count,
+                "total_size": total_size,
+            }
+
     def flattened_document_references(self) -> Generator[dict, None, None]:
         """generator that yields document references populated
         with DocumentReference.subject fields and Observation codes through Observation.focus
@@ -666,6 +706,7 @@ def create_dataframe(
         "MedicationAdministration": db.flattened_medication_administrations,
         "Specimen": db.flattened_specimens,
         "GroupMember": db.flattened_group_members,
+        "PathAggregation": db.path_aggregation,
     }
 
     if data_type in data_type_to_flatten_fn:

--- a/gen3_tracker/meta/path_aggregation.py
+++ b/gen3_tracker/meta/path_aggregation.py
@@ -1,0 +1,36 @@
+import re
+from collections import defaultdict
+
+
+def normalize_path(p: str) -> str:
+    """Normalize a POSIX-like path: keep a leading slash, collapse //, strip trailing slash (except root)."""
+    if not p:
+        return ""
+    if not p.startswith("/"):
+        p = "/" + p
+    p = re.sub(r"/+", "/", p)
+    if p != "/":
+        p = p.rstrip("/")
+    return p
+
+
+def path_prefixes(p: str):
+    """
+    Yield directory prefixes excluding the filename.
+    '/a/b/c.txt' -> '/a', '/a/b'
+    """
+    p = normalize_path(p)
+    if not p or p == "/":
+        return
+    parts = p.lstrip("/").split("/")
+    if len(parts) < 2:
+        return
+    for i in range(1, len(parts)):
+        if i == len(parts) - 1:
+            yield "/" + "/".join(parts[:i])
+
+
+aggregator: dict[str, tuple[int, int]] = defaultdict(lambda: (0, 0))
+"""
+In-memory aggregation of (file_count, total_size) by (path).
+"""

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name='gen3_tracker',
-    version='0.0.7rc22',
+    version='0.0.8rc1',
     description='A CLI for adding version control to Gen3 data submission projects.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/unit/dataframer/test_dataframer.py
+++ b/tests/unit/dataframer/test_dataframer.py
@@ -392,6 +392,24 @@ def test_flattened_document_references(local_db, docref_row):
     assert doc_ref == docref_row
 
 
+def test_path_aggregation(local_db):
+    """Test the dataframer using a local database with a SMMART bundle,
+    this test ensures the  DocumentReference are aggregated correctly by source_path
+    """
+
+    # get the singular test document reference
+    path_aggregations = [d for d in local_db.path_aggregation()]
+    assert len(path_aggregations) == 2, f"Expected 2 path aggregations, got {len(path_aggregations)}"
+    for path_aggregation in path_aggregations:
+        for key in ["path", "file_count", "total_size"]:
+            assert key in path_aggregation, f"Missing key {key} in path aggregation {path_aggregation}"
+    lookup_by_path = {p["path"]: p for p in path_aggregations}
+    assert lookup_by_path["/home/LabA"]["file_count"] == 1
+    assert lookup_by_path["/home/LabA"]["total_size"] == 5595609484
+    assert lookup_by_path["/home/LabA"]["file_count"] == lookup_by_path["/"]["file_count"]
+    assert lookup_by_path["/home/LabA"]["total_size"] == lookup_by_path["/"]["total_size"]
+
+
 def test_flattened_specimens(local_db, specimen_row):
     """Test that the Specimen metadata is populated with the correct Observation codes through Observation.focus"""
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Pull Request Overview

This PR adds a new `PathAggregation` feature that provides file count and size statistics grouped by directory paths from DocumentReference data.

- Introduces a new path aggregation module with utilities for normalizing paths and generating directory prefixes
- Adds a `path_aggregation` method to the dataframer that aggregates DocumentReference files by path
- Extends the CLI to support the new PathAggregation data type

### Reviewed Changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 5 comments.

| File | Description |
| ---- | ----------- |
| gen3_tracker/meta/path_aggregation.py | New module with path normalization utilities and global aggregator state |
| gen3_tracker/meta/dataframer.py | Adds path_aggregation method and registers PathAggregation data type |
| gen3_tracker/meta/cli.py | Extends CLI choices to include PathAggregation option |
| tests/unit/dataframer/test_dataframer.py | Adds comprehensive test for path aggregation functionality |




## Motivation and Context
Provides path hierarchy

## How Has This Been Tested?
See unit test
## Types of Changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] I have updated the documentation accordingly (link here).
- [x] I have tested that this feature locally.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Reviewer has tested this feature locally
